### PR TITLE
Upgrade python-jose to 3.5.0

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,7 +23,7 @@ av>=12.0.0  # PyAV for secure RTSP (rtsps://) streams
 
 # Security and Encryption
 cryptography==44.0.1
-python-jose[cryptography]==3.3.0
+python-jose[cryptography]==3.5.0
 bcrypt>=4.2.0
 slowapi>=0.1.9
 


### PR DESCRIPTION
Upgraded from 3.3.0 to 3.5.0 (latest) to resolve dependency conflicts with pyasn1/pyasn1-modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)