### PR TITLE
fix: Store CORS_ORIGINS as string to avoid pydantic-settings JSON parsing

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,6 +1,5 @@
 """Application configuration using Pydantic Settings"""
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from pydantic import field_validator
 from typing import List
 import secrets
 
@@ -23,15 +22,13 @@ class Settings(BaseSettings):
 
     # API
     API_V1_PREFIX: str = "/api/v1"
-    CORS_ORIGINS: List[str] = ["http://localhost:3000", "http://localhost:8000"]
+    # Stored as string to avoid pydantic-settings JSON parsing; use cors_origins_list property
+    CORS_ORIGINS: str = "http://localhost:3000,http://localhost:8000"
 
-    @field_validator("CORS_ORIGINS", mode="before")
-    @classmethod
-    def parse_cors_origins(cls, v):
-        """Parse CORS_ORIGINS from comma-separated string or list"""
-        if isinstance(v, str):
-            return [origin.strip() for origin in v.split(",") if origin.strip()]
-        return v
+    @property
+    def cors_origins_list(self) -> List[str]:
+        """Parse CORS_ORIGINS from comma-separated string"""
+        return [origin.strip() for origin in self.CORS_ORIGINS.split(",") if origin.strip()]
 
     # Camera Settings
     MAX_CAMERAS: int = 1  # MVP limitation

--- a/backend/main.py
+++ b/backend/main.py
@@ -642,7 +642,7 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 # Configure CORS
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=settings.CORS_ORIGINS,
+    allow_origins=settings.cors_origins_list,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -663,9 +663,9 @@ async def cors_http_exception_handler(request: Request, exc: HTTPException):
 
     # Build CORS headers if origin is allowed
     cors_headers = {}
-    if origin in settings.CORS_ORIGINS or "*" in settings.CORS_ORIGINS:
+    if origin in settings.cors_origins_list or "*" in settings.cors_origins_list:
         cors_headers = {
-            "Access-Control-Allow-Origin": origin or settings.CORS_ORIGINS[0],
+            "Access-Control-Allow-Origin": origin or settings.cors_origins_list[0],
             "Access-Control-Allow-Credentials": "true",
         }
 


### PR DESCRIPTION
## Summary
- Fixes startup crash when `CORS_ORIGINS` is set in `.env` file
- pydantic-settings v2 tries to JSON-parse `List[str]` fields **before** validators run
- Changed `CORS_ORIGINS` from `List[str]` to `str` type
- Added `cors_origins_list` property that parses comma-separated values
- Updated `main.py` to use the new property

## Test plan
- [ ] Fresh install with `CORS_ORIGINS=http://localhost:3000,http://localhost:8000` in `.env`
- [ ] Run `alembic upgrade head` without errors
- [ ] Start app with `uvicorn main:app --reload`
- [ ] Verify CORS headers work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)