### PR TITLE
fix: Use batch mode for SQLite migration 012

### DIFF
--- a/backend/alembic/versions/012_add_protect_controllers_and_camera_extensions.py
+++ b/backend/alembic/versions/012_add_protect_controllers_and_camera_extensions.py
@@ -36,23 +36,21 @@ def upgrade():
         sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
     )
 
-    # Add Phase 2 columns to cameras table
-    op.add_column('cameras', sa.Column('source_type', sa.String(20), nullable=False, server_default='rtsp'))
-    op.add_column('cameras', sa.Column('protect_controller_id', sa.String(36), nullable=True))
-    op.add_column('cameras', sa.Column('protect_camera_id', sa.String(100), nullable=True))
-    op.add_column('cameras', sa.Column('protect_camera_type', sa.String(20), nullable=True))
-    op.add_column('cameras', sa.Column('smart_detection_types', sa.Text(), nullable=True))
-    op.add_column('cameras', sa.Column('is_doorbell', sa.Boolean(), nullable=False, server_default='0'))
-
-    # Add foreign key constraint
-    op.create_foreign_key(
-        'fk_cameras_protect_controller',
-        'cameras',
-        'protect_controllers',
-        ['protect_controller_id'],
-        ['id'],
-        ondelete='SET NULL'
-    )
+    # Add Phase 2 columns to cameras table and foreign key using batch mode for SQLite
+    with op.batch_alter_table('cameras', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('source_type', sa.String(20), nullable=False, server_default='rtsp'))
+        batch_op.add_column(sa.Column('protect_controller_id', sa.String(36), nullable=True))
+        batch_op.add_column(sa.Column('protect_camera_id', sa.String(100), nullable=True))
+        batch_op.add_column(sa.Column('protect_camera_type', sa.String(20), nullable=True))
+        batch_op.add_column(sa.Column('smart_detection_types', sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column('is_doorbell', sa.Boolean(), nullable=False, server_default='0'))
+        batch_op.create_foreign_key(
+            'fk_cameras_protect_controller',
+            'protect_controllers',
+            ['protect_controller_id'],
+            ['id'],
+            ondelete='SET NULL'
+        )
 
     # Create indexes for efficient lookups
     op.create_index('idx_cameras_protect_camera_id', 'cameras', ['protect_camera_id'])
@@ -66,16 +64,15 @@ def downgrade():
     op.drop_index('idx_cameras_source_type', 'cameras')
     op.drop_index('idx_cameras_protect_camera_id', 'cameras')
 
-    # Drop foreign key constraint
-    op.drop_constraint('fk_cameras_protect_controller', 'cameras', type_='foreignkey')
-
-    # Drop Phase 2 columns from cameras
-    op.drop_column('cameras', 'is_doorbell')
-    op.drop_column('cameras', 'smart_detection_types')
-    op.drop_column('cameras', 'protect_camera_type')
-    op.drop_column('cameras', 'protect_camera_id')
-    op.drop_column('cameras', 'protect_controller_id')
-    op.drop_column('cameras', 'source_type')
+    # Drop foreign key and columns using batch mode for SQLite
+    with op.batch_alter_table('cameras', schema=None) as batch_op:
+        batch_op.drop_constraint('fk_cameras_protect_controller', type_='foreignkey')
+        batch_op.drop_column('is_doorbell')
+        batch_op.drop_column('smart_detection_types')
+        batch_op.drop_column('protect_camera_type')
+        batch_op.drop_column('protect_camera_id')
+        batch_op.drop_column('protect_controller_id')
+        batch_op.drop_column('source_type')
 
     # Drop protect_controllers table
     op.drop_table('protect_controllers')


### PR DESCRIPTION
## Summary
- Fixes `NotImplementedError: No support for ALTER of constraints in SQLite dialect` on fresh install
- SQLite doesn't support `ALTER TABLE` for adding/dropping foreign key constraints
- Uses `batch_alter_table()` which creates a new table, copies data, and renames

## Test plan
- [ ] Fresh install with SQLite database
- [ ] Run `alembic upgrade head` without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)