### PR TITLE
fix: Use opencv-python-headless for server installations

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,7 +18,7 @@ pydantic>=2.10.0
 pydantic-settings>=2.6.0
 
 # Camera and Image Processing
-opencv-python>=4.12.0
+opencv-python-headless>=4.12.0  # Headless version for servers (no GUI/libGL dependency)
 av>=12.0.0  # PyAV for secure RTSP (rtsps://) streams
 
 # Security and Encryption


### PR DESCRIPTION
## Summary
- Fixes `ImportError: libGL.so.1: cannot open shared object file` on headless servers
- Switches from `opencv-python` to `opencv-python-headless`
- Same functionality without requiring GUI/graphics libraries

## Test plan
- [ ] Fresh install on headless server
- [ ] `uvicorn main:app` starts without libGL errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)