### PR TITLE
fix: Use POST for protect camera enable/disable endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,8 @@ PUT    /api/v1/protect/controllers/{id}     # Update controller
 DELETE /api/v1/protect/controllers/{id}     # Delete controller
 POST   /api/v1/protect/controllers/test     # Test connection (no persistence)
 GET    /api/v1/protect/controllers/{id}/cameras           # Discover cameras
-PUT    /api/v1/protect/controllers/{id}/cameras/{cam}/enable   # Enable for AI
-PUT    /api/v1/protect/controllers/{id}/cameras/{cam}/disable  # Disable for AI
+POST   /api/v1/protect/controllers/{id}/cameras/{cam}/enable   # Enable for AI
+POST   /api/v1/protect/controllers/{id}/cameras/{cam}/disable  # Disable for AI
 PUT    /api/v1/protect/controllers/{id}/cameras/{cam}/filters  # Set event filters
 ```
 

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -1457,7 +1457,7 @@ export const apiClient = {
         is_enabled_for_ai: boolean;
         smart_detection_types: string[];
       } }>(`/protect/controllers/${controllerId}/cameras/${protectCameraId}/enable`, {
-        method: 'PUT',
+        method: 'POST',
       });
       return response.data;
     },
@@ -1476,7 +1476,7 @@ export const apiClient = {
         protect_camera_id: string;
         is_enabled_for_ai: boolean;
       } }>(`/protect/controllers/${controllerId}/cameras/${protectCameraId}/disable`, {
-        method: 'PUT',
+        method: 'POST',
       });
       return response.data;
     },


### PR DESCRIPTION
## Summary
- Frontend was using `PUT` method for enable/disable camera endpoints
- Backend expects `POST` for action endpoints
- Fixes 405 Method Not Allowed errors when enabling/disabling cameras
- Also updates CLAUDE.md documentation

## Test plan
- [ ] Enable a camera on Protect controller page
- [ ] Disable a camera on Protect controller page

🤖 Generated with [Claude Code](https://claude.com/claude-code)