### PR TITLE
fix: Load AI providers status from API on settings page

### DIFF
--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -181,11 +181,19 @@ export default function SettingsPage() {
   };
 
   const loadAIProvidersStatus = async () => {
-    // TODO: Implement AI providers status API endpoint
-    // For now, start with default empty state - providers will be configured manually
     try {
-      // Stub - this endpoint doesn't exist in api-client yet
-      console.log('AI providers status loading not yet implemented');
+      const response = await apiClient.settings.getAIProvidersStatus();
+      // Convert provider status to Set of configured providers
+      const configured = new Set<AIProvider>(
+        response.providers
+          .filter(p => p.configured)
+          .map(p => p.provider as AIProvider)
+      );
+      setConfiguredProviders(configured);
+      // Update provider order if returned
+      if (response.order && response.order.length > 0) {
+        setProviderOrder(response.order as AIProvider[]);
+      }
     } catch (error) {
       console.error('Failed to load AI providers status:', error);
     }


### PR DESCRIPTION
## Summary
- Replace stub `loadAIProvidersStatus` implementation with actual API call
- Function now calls `getAIProvidersStatus` endpoint
- Updates `configuredProviders` state so saved API keys appear as configured in the UI

## Problem
AI API keys were being saved to the database (verified via direct DB query) but the settings page showed them as "not configured" after page reload. This was because `loadAIProvidersStatus` was a stub that just logged a message instead of calling the API.

## Test plan
- [ ] Save an AI API key in settings
- [ ] Refresh the page
- [ ] Verify the provider shows as "Configured" with a green checkmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)