### PR TITLE
fix: Use string type for event ID in feedback API calls

### DIFF
--- a/frontend/hooks/useFeedback.ts
+++ b/frontend/hooks/useFeedback.ts
@@ -27,7 +27,7 @@ export function useSubmitFeedback() {
   return useMutation<IEvent, ApiError, SubmitFeedbackParams>({
     mutationFn: async ({ eventId, rating, correction }) => {
       const feedback = { rating, correction: correction ?? null };
-      return apiClient.events.submitFeedback(Number(eventId), feedback);
+      return apiClient.events.submitFeedback(eventId, feedback);
     },
     onSuccess: (_data, variables) => {
       // Invalidate event queries to refresh feedback data
@@ -51,7 +51,7 @@ export function useUpdateFeedback() {
   return useMutation<IEvent, ApiError, SubmitFeedbackParams>({
     mutationFn: async ({ eventId, rating, correction }) => {
       const feedback = { rating, correction: correction ?? null };
-      return apiClient.events.submitFeedback(Number(eventId), feedback);
+      return apiClient.events.submitFeedback(eventId, feedback);
     },
     onSuccess: (_data, variables) => {
       // Invalidate event queries to refresh feedback data
@@ -75,7 +75,7 @@ export function useDeleteFeedback() {
   return useMutation<IEvent, ApiError, string>({
     mutationFn: async (eventId) => {
       // Delete feedback by submitting empty feedback
-      return apiClient.events.submitFeedback(Number(eventId), { rating: 'helpful' });
+      return apiClient.events.submitFeedback(eventId, { rating: 'helpful' });
     },
     onSuccess: (_, eventId) => {
       // Invalidate event queries to refresh feedback data

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -459,7 +459,7 @@ export const apiClient = {
      * @param feedback Feedback data (rating, optional correction)
      * @returns Updated event with feedback
      */
-    submitFeedback: async (eventId: number, feedback: { rating: 'helpful' | 'not_helpful'; correction?: string | null }): Promise<IEvent> => {
+    submitFeedback: async (eventId: string, feedback: { rating: 'helpful' | 'not_helpful'; correction?: string | null }): Promise<IEvent> => {
       return apiFetch(`/events/${eventId}/feedback`, {
         method: 'POST',
         body: JSON.stringify(feedback),


### PR DESCRIPTION
## Summary
- Change `submitFeedback` to accept `string` eventId instead of `number` in api-client.ts
- Remove `Number(eventId)` conversions in useFeedback.ts hooks

## Problem
Event IDs are UUIDs (strings), but the feedback API was trying to convert them to numbers:
```
Number("abc-123-uuid") → NaN
```
This resulted in requests to `/events/NaN/feedback` returning 404 errors.

## Test plan
- [ ] Click thumbs up or thumbs down on an event card
- [ ] Verify feedback is submitted successfully (no 404 error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)