### PR TITLE
fix: Improve push notification HTTPS requirement messaging

### DIFF
--- a/frontend/components/settings/PushNotificationSettings.tsx
+++ b/frontend/components/settings/PushNotificationSettings.tsx
@@ -129,18 +129,38 @@ function PermissionDeniedBanner() {
  * Unsupported Browser Banner
  */
 function UnsupportedBanner() {
+  // Check if the issue is HTTP vs HTTPS
+  const isInsecureOrigin = typeof window !== 'undefined' &&
+    !window.isSecureContext &&
+    window.location.hostname !== 'localhost' &&
+    window.location.hostname !== '127.0.0.1';
+
   return (
     <Alert className="mt-4">
       <Info className="h-4 w-4" />
       <AlertTitle>Push Notifications Not Available</AlertTitle>
       <AlertDescription>
-        <p>
-          Your browser does not support push notifications. To receive notifications,
-          please use a modern browser like Chrome, Firefox, Edge, or Safari 16+.
-        </p>
-        <p className="mt-2 text-sm text-muted-foreground">
-          On iOS, push notifications require installing this app as a PWA (Add to Home Screen).
-        </p>
+        {isInsecureOrigin ? (
+          <>
+            <p>
+              Push notifications require a <strong>secure connection (HTTPS)</strong>.
+              You are currently accessing this site over HTTP.
+            </p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              To enable push notifications, configure HTTPS for your server or access via localhost.
+            </p>
+          </>
+        ) : (
+          <>
+            <p>
+              Your browser does not support push notifications. To receive notifications,
+              please use a modern browser like Chrome, Firefox, Edge, or Safari 16+.
+            </p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              On iOS, push notifications require installing this app as a PWA (Add to Home Screen).
+            </p>
+          </>
+        )}
       </AlertDescription>
     </Alert>
   );

--- a/frontend/hooks/usePushNotifications.ts
+++ b/frontend/hooks/usePushNotifications.ts
@@ -150,10 +150,15 @@ export function usePushNotifications(): UsePushNotificationsReturn {
   const swRegistrationInProgress = useRef(false);
 
   // Check browser support
+  // Note: Push API requires HTTPS (secure context) except for localhost
+  const isSecureContext = typeof window !== 'undefined' &&
+    (window.isSecureContext || window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
+
   const isPushSupported = typeof window !== 'undefined' &&
     'Notification' in window &&
     'serviceWorker' in navigator &&
-    'PushManager' in window;
+    'PushManager' in window &&
+    isSecureContext;
 
   const hasServiceWorker = typeof navigator !== 'undefined' &&
     'serviceWorker' in navigator;


### PR DESCRIPTION
## Summary
- Add secure context check to `isPushSupported` detection
- Update UnsupportedBanner to show specific message about HTTPS requirement when accessed over HTTP

## Problem
Push notifications require HTTPS (secure context) except for localhost. When accessing ArgusAI via `http://argusai.bengtson.local:3000`, the browser hides the PushManager API entirely. The previous error message said "Your browser does not support push notifications" which was misleading since Chrome does support them - just not over HTTP.

## Solution
Now the banner will show:
> Push notifications require a **secure connection (HTTPS)**. You are currently accessing this site over HTTP.

## Test plan
- [ ] Access site over HTTP - should see HTTPS requirement message
- [ ] Access site over HTTPS or localhost - should work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)