### PR TITLE
fix: Disable Next.js image optimization for self-hosted deployments

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,17 +2,10 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: {
-    remotePatterns: [
-      {
-        protocol: 'http',
-        hostname: 'localhost',
-        port: '8000',
-        pathname: '/api/v1/thumbnails/**',
-      },
-    ],
-    // Allow localhost for development
+    // Disable image optimization for self-hosted deployments
+    // This allows images from any hostname (localhost, IP, custom domain)
+    unoptimized: true,
     dangerouslyAllowSVG: true,
-    unoptimized: process.env.NODE_ENV === 'development',
   },
   // Proxy API requests to backend to avoid CORS issues
   async rewrites() {


### PR DESCRIPTION
## Summary
- Disable Next.js Image optimization (`unoptimized: true`)
- Removes hostname whitelist requirement

## Problem
Next.js Image component requires domains to be whitelisted in `remotePatterns`. When accessing via custom hostname (`argusai.bengtson.local:8000`) instead of `localhost:8000`, images fail with 400 Bad Request.

## Solution
Set `unoptimized: true` to bypass Next.js image optimization entirely. This is appropriate for self-hosted apps that may be accessed via various hostnames.

## Test plan
- [ ] Access app via custom hostname
- [ ] Verify thumbnails and event frames load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)