### PR TITLE
fix: Correct bulk delete endpoint and parameter format

### DIFF
--- a/frontend/app/events/page.tsx
+++ b/frontend/app/events/page.tsx
@@ -194,7 +194,7 @@ export default function EventsPage() {
 
     setIsDeleting(true);
     try {
-      const result = await apiClient.events.deleteMany(Array.from(selectedIds).map(Number));
+      const result = await apiClient.events.deleteMany(Array.from(selectedIds));
       toast.success(`Deleted ${result.deleted_count} events`);
       setSelectedIds(new Set());
       setSelectionMode(false);

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -379,10 +379,10 @@ export const apiClient = {
     /**
      * Delete multiple events
      */
-    deleteMany: async (ids: number[]): Promise<{ deleted_count: number }> => {
-      return apiFetch('/events/bulk-delete', {
+    deleteMany: async (ids: string[]): Promise<{ deleted_count: number }> => {
+      const queryParams = ids.map(id => `event_ids=${encodeURIComponent(id)}`).join('&');
+      return apiFetch(`/events/bulk?${queryParams}`, {
         method: 'DELETE',
-        body: JSON.stringify({ event_ids: ids }),
       });
     },
 


### PR DESCRIPTION
## Summary
- Change endpoint from `/events/bulk-delete` to `/events/bulk`
- Use query parameters instead of JSON body
- Pass event IDs as strings (UUIDs) not numbers

## Problem
Frontend was calling `/events/bulk-delete` but backend expects `DELETE /events/bulk?event_ids=...`

## Test plan
- [ ] Select multiple events on Events page
- [ ] Click delete and confirm
- [ ] Verify events are deleted successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)