### PR TITLE
fix: Use string type for event ID in single delete

### DIFF
--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -370,7 +370,7 @@ export const apiClient = {
     /**
      * Delete single event
      */
-    delete: async (id: number): Promise<void> => {
+    delete: async (id: string): Promise<void> => {
       return apiFetch(`/events/${id}`, {
         method: 'DELETE',
       });

--- a/frontend/lib/hooks/useEvents.ts
+++ b/frontend/lib/hooks/useEvents.ts
@@ -59,7 +59,7 @@ export function useDeleteEvent() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (eventId: string) => apiClient.events.delete(Number(eventId)),
+    mutationFn: (eventId: string) => apiClient.events.delete(eventId),
     onMutate: async (eventId) => {
       // Cancel outgoing refetches
       await queryClient.cancelQueries({ queryKey: ['events'] });


### PR DESCRIPTION
## Summary
- Change `events.delete` to accept string ID instead of number
- Remove `Number()` conversion in `useDeleteEvent` hook

## Problem
Event IDs are UUIDs (strings). `Number("uuid-string")` returns `NaN`, causing `DELETE /events/NaN` which returns 404.

## Test plan
- [ ] Delete a single event from event card
- [ ] Verify event is deleted successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)