### PR TITLE
feat: Add summary feedback buttons (P9-3.4)

### DIFF
--- a/backend/alembic/versions/19df889882ef_add_summary_feedback_table.py
+++ b/backend/alembic/versions/19df889882ef_add_summary_feedback_table.py
@@ -1,0 +1,39 @@
+"""add_summary_feedback_table
+
+Revision ID: 19df889882ef
+Revises: b875e9bd8602
+Create Date: 2025-12-22 16:11:28.045294
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '19df889882ef'
+down_revision = 'b875e9bd8602'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create summary_feedback table for Story P9-3.4"""
+    op.create_table(
+        'summary_feedback',
+        sa.Column('id', sa.String(), nullable=False),
+        sa.Column('summary_id', sa.String(), nullable=False),
+        sa.Column('rating', sa.String(20), nullable=False),
+        sa.Column('correction_text', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(['summary_id'], ['activity_summaries.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('summary_id', name='uq_summary_feedback_summary_id')
+    )
+    op.create_index('ix_summary_feedback_summary_id', 'summary_feedback', ['summary_id'], unique=True)
+
+
+def downgrade() -> None:
+    """Drop summary_feedback table"""
+    op.drop_index('ix_summary_feedback_summary_id', table_name='summary_feedback')
+    op.drop_table('summary_feedback')

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -17,6 +17,7 @@ from app.models.recognized_entity import RecognizedEntity, EntityEvent
 from app.models.camera_activity_pattern import CameraActivityPattern
 from app.models.activity_summary import ActivitySummary
 from app.models.event_feedback import EventFeedback
+from app.models.summary_feedback import SummaryFeedback
 from app.models.prompt_history import PromptHistory
 from app.models.face_embedding import FaceEmbedding
 from app.models.vehicle_embedding import VehicleEmbedding
@@ -43,6 +44,7 @@ __all__ = [
     "CameraActivityPattern",
     "ActivitySummary",
     "EventFeedback",
+    "SummaryFeedback",
     "PromptHistory",
     "FaceEmbedding",
     "VehicleEmbedding",

--- a/backend/app/models/activity_summary.py
+++ b/backend/app/models/activity_summary.py
@@ -1,15 +1,17 @@
 """
-ActivitySummary Model (Story P4-4.1, P4-4.2)
+ActivitySummary Model (Story P4-4.1, P4-4.2, P9-3.4)
 
 Stores generated activity summaries for caching and historical access.
 Summaries can be generated on-demand or scheduled via DigestScheduler.
 
 Story P4-4.2: Added digest_type column to distinguish scheduled digests.
+Story P9-3.4: Added feedback relationship for summary feedback.
 """
 import uuid
 from datetime import datetime, timezone
 
 from sqlalchemy import Column, String, Text, DateTime, Integer, Float
+from sqlalchemy.orm import relationship
 
 from app.core.database import Base
 
@@ -123,6 +125,14 @@ class ActivitySummary(Base):
         Text,
         nullable=True,
         doc="JSON object with delivery status per channel: {channels_succeeded: [], errors: {}, delivery_time_ms: int}"
+    )
+
+    # Story P9-3.4: Relationship to SummaryFeedback
+    feedback = relationship(
+        "SummaryFeedback",
+        back_populates="summary",
+        uselist=False,
+        cascade="all, delete-orphan"
     )
 
     def __repr__(self) -> str:

--- a/backend/app/models/summary_feedback.py
+++ b/backend/app/models/summary_feedback.py
@@ -1,0 +1,59 @@
+"""SummaryFeedback SQLAlchemy ORM model for user feedback on activity summaries
+
+Story P9-3.4: Add Summary Feedback Buttons
+"""
+from sqlalchemy import Column, String, Text, DateTime, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import relationship
+from app.core.database import Base
+import uuid
+from datetime import datetime, timezone
+
+
+class SummaryFeedback(Base):
+    """
+    User feedback on AI-generated activity summaries.
+
+    Allows users to rate summaries as positive/negative and provide
+    optional correction text to improve AI summarization accuracy over time.
+
+    Attributes:
+        id: UUID primary key
+        summary_id: Foreign key to activity_summaries table (unique - one feedback per summary)
+        rating: User rating - 'positive' or 'negative'
+        correction_text: Optional correction text (max 500 chars enforced at API level)
+        created_at: When feedback was submitted
+        updated_at: When feedback was last modified
+    """
+
+    __tablename__ = "summary_feedback"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    summary_id = Column(
+        String,
+        ForeignKey('activity_summaries.id', ondelete='CASCADE'),
+        nullable=False,
+        unique=True,  # One feedback per summary
+        index=True
+    )
+    rating = Column(String(20), nullable=False)  # 'positive' or 'negative'
+    correction_text = Column(Text, nullable=True)  # Optional correction text
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=True,
+        onupdate=lambda: datetime.now(timezone.utc)
+    )
+
+    # Relationship back to ActivitySummary
+    summary = relationship("ActivitySummary", back_populates="feedback")
+
+    __table_args__ = (
+        UniqueConstraint('summary_id', name='uq_summary_feedback_summary_id'),
+    )
+
+    def __repr__(self):
+        return f"<SummaryFeedback(id={self.id}, summary_id={self.summary_id}, rating={self.rating})>"

--- a/backend/app/schemas/feedback.py
+++ b/backend/app/schemas/feedback.py
@@ -3,6 +3,7 @@
 Story P4-5.1: Feedback Collection UI
 Story P4-5.2: Feedback Storage & API - Added statistics schemas
 Story P9-3.3: Package False Positive Feedback - Added correction_type
+Story P9-3.4: Add Summary Feedback Buttons - Added summary feedback schemas
 """
 from pydantic import BaseModel, Field
 from typing import Literal, Optional, Dict, List
@@ -125,5 +126,47 @@ class FeedbackStatsResponse(BaseModel):
         default_factory=list,
         description="Most common correction patterns (top 10)"
     )
+
+    model_config = {"from_attributes": True}
+
+
+# ============================================================================
+# Story P9-3.4: Summary Feedback Schemas
+# ============================================================================
+
+class SummaryFeedbackCreate(BaseModel):
+    """Schema for creating new feedback on a summary."""
+    rating: Literal['positive', 'negative'] = Field(
+        ...,
+        description="User's rating of the summary"
+    )
+    correction_text: Optional[str] = Field(
+        None,
+        max_length=500,
+        description="Optional correction text (max 500 characters)"
+    )
+
+
+class SummaryFeedbackUpdate(BaseModel):
+    """Schema for updating existing summary feedback."""
+    rating: Optional[Literal['positive', 'negative']] = Field(
+        None,
+        description="Updated rating (optional)"
+    )
+    correction_text: Optional[str] = Field(
+        None,
+        max_length=500,
+        description="Updated correction text (max 500 characters)"
+    )
+
+
+class SummaryFeedbackResponse(BaseModel):
+    """Schema for summary feedback response."""
+    id: str
+    summary_id: str
+    rating: str
+    correction_text: Optional[str] = None
+    created_at: datetime
+    updated_at: Optional[datetime] = None
 
     model_config = {"from_attributes": True}

--- a/backend/tests/test_api/test_summary_feedback.py
+++ b/backend/tests/test_api/test_summary_feedback.py
@@ -1,0 +1,317 @@
+"""
+Tests for Summary Feedback API endpoints (Story P9-3.4)
+"""
+import os
+import tempfile
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import uuid
+from datetime import datetime, timezone
+
+from main import app
+from app.core.database import Base, get_db
+from app.models.activity_summary import ActivitySummary
+from app.models.summary_feedback import SummaryFeedback
+
+
+# Create module-level temp database (file-based for isolation)
+_test_db_fd, _test_db_path = tempfile.mkstemp(suffix=".db")
+os.close(_test_db_fd)
+
+SQLALCHEMY_DATABASE_URL = f"sqlite:///{_test_db_path}"
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def _override_get_db():
+    """Override dependency to use test database"""
+    db = TestingSessionLocal()
+    try:
+        yield db
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_module_database():
+    """Set up database and override at module start, teardown at end."""
+    Base.metadata.create_all(bind=engine)
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    Base.metadata.drop_all(bind=engine)
+    engine.dispose()
+    # Clean up temp file
+    if os.path.exists(_test_db_path):
+        os.remove(_test_db_path)
+
+
+@pytest.fixture(scope="function")
+def clean_db():
+    """Clean up all data before each test function."""
+    # Clean up data from previous test
+    db = TestingSessionLocal()
+    try:
+        for table in reversed(Base.metadata.sorted_tables):
+            try:
+                db.execute(table.delete())
+            except Exception:
+                pass
+        db.commit()
+    finally:
+        db.close()
+    yield
+    # Also clean after test
+    db = TestingSessionLocal()
+    try:
+        for table in reversed(Base.metadata.sorted_tables):
+            try:
+                db.execute(table.delete())
+            except Exception:
+                pass
+        db.commit()
+    finally:
+        db.close()
+
+
+@pytest.fixture
+def client(clean_db):
+    """Create test client - override already applied at module level"""
+    yield TestClient(app)
+
+
+@pytest.fixture
+def db_session(clean_db):
+    """Get database session for test setup"""
+    return TestingSessionLocal()
+
+
+@pytest.fixture
+def test_summary(db_session) -> ActivitySummary:
+    """Create a test summary"""
+    summary = ActivitySummary(
+        id=str(uuid.uuid4()),
+        summary_text="Test summary for today's activity",
+        period_start=datetime.now(timezone.utc),
+        period_end=datetime.now(timezone.utc),
+        event_count=10,
+        generated_at=datetime.now(timezone.utc),
+        ai_cost=0.01,
+        provider_used="openai",
+        input_tokens=100,
+        output_tokens=50,
+        digest_type="daily"
+    )
+    db_session.add(summary)
+    db_session.commit()
+    db_session.refresh(summary)
+    return summary
+
+
+class TestSummaryFeedbackEndpoints:
+    """Test suite for summary feedback API endpoints (Story P9-3.4)"""
+
+    def test_create_feedback_positive(self, client, test_summary: ActivitySummary):
+        """Test creating feedback with positive rating (AC-3.4.2)"""
+        response = client.post(
+            f"/api/v1/summaries/{test_summary.id}/feedback",
+            json={"rating": "positive"}
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["summary_id"] == test_summary.id
+        assert data["rating"] == "positive"
+        assert data["correction_text"] is None
+        assert "id" in data
+        assert "created_at" in data
+
+    def test_create_feedback_negative(self, client, test_summary: ActivitySummary):
+        """Test creating feedback with negative rating (AC-3.4.4)"""
+        response = client.post(
+            f"/api/v1/summaries/{test_summary.id}/feedback",
+            json={"rating": "negative"}
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["rating"] == "negative"
+
+    def test_create_feedback_with_correction_text(self, client, test_summary: ActivitySummary):
+        """Test creating feedback with correction text (AC-3.4.5)"""
+        correction = "Summary missed the morning package delivery"
+        response = client.post(
+            f"/api/v1/summaries/{test_summary.id}/feedback",
+            json={
+                "rating": "negative",
+                "correction_text": correction
+            }
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["correction_text"] == correction
+        assert data["rating"] == "negative"
+
+    def test_create_feedback_summary_not_found(self, client):
+        """Test creating feedback for non-existent summary"""
+        fake_id = str(uuid.uuid4())
+        response = client.post(
+            f"/api/v1/summaries/{fake_id}/feedback",
+            json={"rating": "positive"}
+        )
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    def test_create_feedback_duplicate(self, client, test_summary: ActivitySummary):
+        """Test creating feedback when one already exists (returns 409)"""
+        # Create initial feedback
+        response1 = client.post(
+            f"/api/v1/summaries/{test_summary.id}/feedback",
+            json={"rating": "positive"}
+        )
+        assert response1.status_code == 201
+
+        # Try to create duplicate
+        response2 = client.post(
+            f"/api/v1/summaries/{test_summary.id}/feedback",
+            json={"rating": "negative"}
+        )
+        assert response2.status_code == 409
+        assert "already exists" in response2.json()["detail"].lower()
+
+    def test_create_feedback_invalid_rating(self, client, test_summary: ActivitySummary):
+        """Test creating feedback with invalid rating value"""
+        response = client.post(
+            f"/api/v1/summaries/{test_summary.id}/feedback",
+            json={"rating": "invalid_rating"}
+        )
+        assert response.status_code == 422  # Validation error
+
+    def test_create_feedback_correction_max_length(self, client, test_summary: ActivitySummary):
+        """Test correction text max length validation"""
+        long_correction = "a" * 501  # Over 500 char limit
+        response = client.post(
+            f"/api/v1/summaries/{test_summary.id}/feedback",
+            json={
+                "rating": "negative",
+                "correction_text": long_correction
+            }
+        )
+        assert response.status_code == 422  # Validation error
+
+    def test_get_feedback(self, client, db_session, test_summary: ActivitySummary):
+        """Test getting feedback for a summary (AC-3.4.3)"""
+        # Create feedback directly
+        feedback = SummaryFeedback(
+            summary_id=test_summary.id,
+            rating="positive"
+        )
+        db_session.add(feedback)
+        db_session.commit()
+
+        response = client.get(f"/api/v1/summaries/{test_summary.id}/feedback")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["summary_id"] == test_summary.id
+        assert data["rating"] == "positive"
+
+    def test_get_feedback_not_found(self, client, test_summary: ActivitySummary):
+        """Test getting feedback when none exists"""
+        response = client.get(f"/api/v1/summaries/{test_summary.id}/feedback")
+        assert response.status_code == 404
+
+    def test_get_feedback_summary_not_found(self, client):
+        """Test getting feedback for non-existent summary"""
+        fake_id = str(uuid.uuid4())
+        response = client.get(f"/api/v1/summaries/{fake_id}/feedback")
+        assert response.status_code == 404
+
+    def test_update_feedback(self, client, db_session, test_summary: ActivitySummary):
+        """Test updating existing feedback"""
+        # Create initial feedback
+        feedback = SummaryFeedback(
+            summary_id=test_summary.id,
+            rating="positive"
+        )
+        db_session.add(feedback)
+        db_session.commit()
+
+        # Update to negative with correction
+        response = client.put(
+            f"/api/v1/summaries/{test_summary.id}/feedback",
+            json={
+                "rating": "negative",
+                "correction_text": "Updated correction"
+            }
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["rating"] == "negative"
+        assert data["correction_text"] == "Updated correction"
+
+    def test_update_feedback_partial(self, client, db_session, test_summary: ActivitySummary):
+        """Test partial update of feedback (only rating)"""
+        feedback = SummaryFeedback(
+            summary_id=test_summary.id,
+            rating="positive",
+            correction_text="Original correction"
+        )
+        db_session.add(feedback)
+        db_session.commit()
+
+        # Only update rating
+        response = client.put(
+            f"/api/v1/summaries/{test_summary.id}/feedback",
+            json={"rating": "negative"}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["rating"] == "negative"
+        # Original correction should be preserved
+        assert data["correction_text"] == "Original correction"
+
+    def test_update_feedback_not_found(self, client, test_summary: ActivitySummary):
+        """Test updating non-existent feedback"""
+        response = client.put(
+            f"/api/v1/summaries/{test_summary.id}/feedback",
+            json={"rating": "negative"}
+        )
+        assert response.status_code == 404
+
+    def test_delete_feedback(self, client, db_session, test_summary: ActivitySummary):
+        """Test deleting feedback"""
+        feedback = SummaryFeedback(
+            summary_id=test_summary.id,
+            rating="positive"
+        )
+        db_session.add(feedback)
+        db_session.commit()
+
+        response = client.delete(f"/api/v1/summaries/{test_summary.id}/feedback")
+        assert response.status_code == 204
+
+        # Verify deletion
+        get_response = client.get(f"/api/v1/summaries/{test_summary.id}/feedback")
+        assert get_response.status_code == 404
+
+    def test_delete_feedback_not_found(self, client, test_summary: ActivitySummary):
+        """Test deleting non-existent feedback"""
+        response = client.delete(f"/api/v1/summaries/{test_summary.id}/feedback")
+        assert response.status_code == 404
+
+    def test_correction_at_max_length(self, client, test_summary: ActivitySummary):
+        """Test correction text at exactly 500 characters (boundary)"""
+        max_correction = "a" * 500  # Exactly at limit
+        response = client.post(
+            f"/api/v1/summaries/{test_summary.id}/feedback",
+            json={
+                "rating": "negative",
+                "correction_text": max_correction
+            }
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert len(data["correction_text"]) == 500

--- a/docs/sprint-artifacts/p9-3-4-add-summary-feedback-buttons.md
+++ b/docs/sprint-artifacts/p9-3-4-add-summary-feedback-buttons.md
@@ -1,0 +1,76 @@
+# Story P9-3.4: Add Summary Feedback Buttons
+
+## Story Summary
+
+As a user viewing activity summaries, I want to provide feedback on the summary quality, so that I can help improve the AI's summarization accuracy over time.
+
+## Acceptance Criteria
+
+- **AC-3.4.1:** Given daily summary card, when viewing, then thumbs up/down buttons visible
+- **AC-3.4.2:** Given I click thumbs up, when submitted, then positive feedback stored
+- **AC-3.4.3:** Given I click thumbs up, when viewing, then button shows selected state
+- **AC-3.4.4:** Given I click thumbs down, when clicked, then optional correction text modal appears
+- **AC-3.4.5:** Given I submit thumbs down with text, when stored, then correction_text saved
+- **AC-3.4.6:** Given I submit feedback, when complete, then brief toast "Thanks for the feedback!"
+
+## Technical Implementation
+
+### Backend Changes
+
+1. **Create SummaryFeedback model** (`backend/app/models/summary_feedback.py`):
+   - id: UUID
+   - summary_id: FK to ActivitySummary
+   - rating: 'positive' | 'negative'
+   - correction_text: Optional[str]
+   - created_at, updated_at timestamps
+
+2. **Create Alembic migration** for summary_feedback table
+
+3. **Create schemas** (`backend/app/schemas/summary_feedback.py`):
+   - SummaryFeedbackCreate
+   - SummaryFeedbackUpdate
+   - SummaryFeedbackResponse
+
+4. **Add API endpoints** to `backend/app/api/v1/summaries.py`:
+   - POST `/summaries/{summary_id}/feedback` - Create feedback
+   - GET `/summaries/{summary_id}/feedback` - Get feedback
+   - PUT `/summaries/{summary_id}/feedback` - Update feedback
+   - DELETE `/summaries/{summary_id}/feedback` - Delete feedback
+
+### Frontend Changes
+
+1. **Create SummaryFeedbackButtons component** (`frontend/components/summaries/SummaryFeedbackButtons.tsx`):
+   - Thumbs up/down buttons similar to FeedbackButtons.tsx
+   - Selected state styling
+   - Correction text modal on thumbs down
+
+2. **Create useSummaryFeedback hook** (`frontend/hooks/useSummaryFeedback.ts`):
+   - useSubmitSummaryFeedback mutation
+   - useUpdateSummaryFeedback mutation
+   - useSummaryFeedback query
+
+3. **Update SummaryCard component** to include SummaryFeedbackButtons
+
+4. **Add TypeScript types** for SummaryFeedback
+
+### Tests
+
+- Backend: API endpoint tests for CRUD operations
+- Frontend: Component tests for button states and interactions
+
+## Dependencies
+
+- Existing FeedbackButtons component (reference implementation)
+- ActivitySummary model (existing)
+
+## Definition of Done
+
+- [ ] SummaryFeedback model created with migration
+- [ ] API endpoints implemented and tested
+- [ ] SummaryFeedbackButtons component created
+- [ ] useSummaryFeedback hook created
+- [ ] SummaryCard updated with feedback buttons
+- [ ] TypeScript types added
+- [ ] Backend tests pass
+- [ ] Frontend build passes
+- [ ] PR created and merged

--- a/frontend/app/summaries/page.tsx
+++ b/frontend/app/summaries/page.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 /**
- * Summaries Page (Story P4-4.5)
+ * Summaries Page (Story P4-4.5, P9-3.4)
  *
  * Main page for viewing activity summaries and generating on-demand summaries.
  *
  * AC Coverage:
  * - AC6: Summaries page with "Generate Summary" button
  * - AC12: View saved summaries in history
+ * - AC-3.4.1-6: Summary feedback buttons (Story P9-3.4)
  */
 
 import { useState } from 'react';
@@ -28,6 +29,7 @@ import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { GenerateSummaryDialog } from '@/components/summaries/GenerateSummaryDialog';
+import { SummaryFeedbackButtons } from '@/components/summaries/SummaryFeedbackButtons';
 import { useRecentSummaries, useSummaryList, RecentSummaryItem } from '@/hooks/useSummaries';
 import type { SummaryGenerateResponse } from '@/hooks/useSummaries';
 
@@ -97,6 +99,11 @@ function SummaryListItem({ summary }: { summary: RecentSummaryItem | SummaryGene
           <StatBadge icon={Bell} value={summary.doorbell_count} label="doorbells" />
           <StatBadge icon={Users} value={summary.person_count} label="people" />
           <StatBadge icon={Car} value={summary.vehicle_count} label="vehicles" />
+        </div>
+
+        {/* Story P9-3.4: Feedback Buttons (AC-3.4.1) */}
+        <div className="flex justify-end pt-2 border-t mt-3">
+          <SummaryFeedbackButtons summaryId={summary.id} />
         </div>
       </CardContent>
     </Card>

--- a/frontend/components/summaries/SummaryFeedbackButtons.tsx
+++ b/frontend/components/summaries/SummaryFeedbackButtons.tsx
@@ -1,0 +1,241 @@
+/**
+ * Story P9-3.4: Summary Feedback Buttons
+ *
+ * SummaryFeedbackButtons component - allows users to provide quick feedback on AI summaries
+ * using thumbs up/down buttons with optional correction text input.
+ */
+
+'use client';
+
+import { useState, memo, useCallback } from 'react';
+import { ThumbsUp, ThumbsDown, Loader2, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { toast } from 'sonner';
+import {
+  useSummaryFeedback,
+  useSubmitSummaryFeedback,
+  useUpdateSummaryFeedback,
+} from '@/hooks/useSummaryFeedback';
+import type { ISummaryFeedback } from '@/types/event';
+import { cn } from '@/lib/utils';
+
+interface SummaryFeedbackButtonsProps {
+  /** Summary UUID to submit feedback for */
+  summaryId: string;
+  /** Existing feedback if any (for showing selected state) */
+  existingFeedback?: ISummaryFeedback | null;
+  /** Callback when feedback changes */
+  onFeedbackChange?: (feedback: ISummaryFeedback) => void;
+  /** Additional class names */
+  className?: string;
+}
+
+const CORRECTION_MAX_LENGTH = 500;
+
+export const SummaryFeedbackButtons = memo(function SummaryFeedbackButtons({
+  summaryId,
+  existingFeedback,
+  onFeedbackChange,
+  className,
+}: SummaryFeedbackButtonsProps) {
+  const [showCorrection, setShowCorrection] = useState(false);
+  const [correctionText, setCorrectionText] = useState('');
+  const [localFeedback, setLocalFeedback] = useState<ISummaryFeedback | null>(existingFeedback ?? null);
+
+  // Fetch existing feedback if not provided
+  const { data: fetchedFeedback } = useSummaryFeedback(summaryId);
+  const currentFeedback = localFeedback ?? fetchedFeedback ?? existingFeedback;
+
+  const { mutate: submitFeedback, isPending: isSubmitting } = useSubmitSummaryFeedback();
+  const { mutate: updateFeedback, isPending: isUpdating } = useUpdateSummaryFeedback();
+
+  const isPending = isSubmitting || isUpdating;
+
+  // Get current rating
+  const currentRating = currentFeedback?.rating;
+
+  const handleFeedback = useCallback((
+    rating: 'positive' | 'negative',
+    correctionTextValue?: string
+  ) => {
+    const mutationFn = currentRating ? updateFeedback : submitFeedback;
+
+    mutationFn(
+      {
+        summaryId,
+        rating,
+        correctionText: correctionTextValue || undefined,
+      },
+      {
+        onSuccess: (data) => {
+          const feedback: ISummaryFeedback = {
+            id: data.id,
+            summary_id: data.summary_id,
+            rating: data.rating,
+            correction_text: data.correction_text,
+            created_at: data.created_at,
+            updated_at: data.updated_at,
+          };
+          setLocalFeedback(feedback);
+          onFeedbackChange?.(feedback);
+          setShowCorrection(false);
+          setCorrectionText('');
+          toast.success('Thanks for the feedback!', {
+            description: rating === 'positive' ? 'Glad the summary was helpful!' : 'Your feedback helps improve accuracy.',
+          });
+        },
+        onError: (error) => {
+          toast.error('Failed to submit feedback', {
+            description: error.message || 'Please try again.',
+          });
+        },
+      }
+    );
+  }, [summaryId, currentRating, submitFeedback, updateFeedback, onFeedbackChange]);
+
+  const handleThumbsUp = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isPending) return;
+    handleFeedback('positive');
+  }, [handleFeedback, isPending]);
+
+  const handleThumbsDown = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isPending) return;
+    setShowCorrection(true);
+  }, [isPending]);
+
+  const handleSubmitCorrection = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isPending) return;
+    handleFeedback('negative', correctionText);
+  }, [handleFeedback, correctionText, isPending]);
+
+  const handleSkipCorrection = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isPending) return;
+    handleFeedback('negative');
+  }, [handleFeedback, isPending]);
+
+  const handleCancelCorrection = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setShowCorrection(false);
+    setCorrectionText('');
+  }, []);
+
+  const handleCorrectionChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = e.target.value;
+    if (value.length <= CORRECTION_MAX_LENGTH) {
+      setCorrectionText(value);
+    }
+  }, []);
+
+  // Prevent clicks from bubbling
+  const handleContainerClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+  }, []);
+
+  return (
+    <div className={cn("flex flex-col gap-2", className)} onClick={handleContainerClick}>
+      <div className="flex items-center gap-1">
+        {/* Thumbs Up Button */}
+        <Button
+          variant={currentRating === 'positive' ? 'default' : 'ghost'}
+          size="sm"
+          onClick={handleThumbsUp}
+          disabled={isPending}
+          aria-label={currentRating === 'positive' ? 'Marked as helpful' : 'Mark as helpful'}
+          aria-pressed={currentRating === 'positive'}
+          className={cn(
+            "h-8 w-8 p-0",
+            currentRating === 'positive' && "bg-green-600 hover:bg-green-700 text-white"
+          )}
+        >
+          {isPending && !showCorrection ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <ThumbsUp className={cn(
+              "h-4 w-4",
+              currentRating === 'positive' && "fill-current"
+            )} />
+          )}
+        </Button>
+
+        {/* Thumbs Down Button */}
+        <Button
+          variant={currentRating === 'negative' ? 'default' : 'ghost'}
+          size="sm"
+          onClick={handleThumbsDown}
+          disabled={isPending}
+          aria-label={currentRating === 'negative' ? 'Marked as not helpful' : 'Mark as not helpful'}
+          aria-pressed={currentRating === 'negative'}
+          className={cn(
+            "h-8 w-8 p-0",
+            currentRating === 'negative' && "bg-red-600 hover:bg-red-700 text-white"
+          )}
+        >
+          <ThumbsDown className={cn(
+            "h-4 w-4",
+            currentRating === 'negative' && "fill-current"
+          )} />
+        </Button>
+      </div>
+
+      {/* Correction Input (shows on thumbs down) - AC-3.4.4 */}
+      {showCorrection && (
+        <div className="flex flex-col gap-2 p-3 bg-muted rounded-lg border animate-in fade-in slide-in-from-top-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium">What was missing? (optional)</span>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleCancelCorrection}
+              className="h-6 w-6 p-0"
+              aria-label="Cancel correction"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+          <Textarea
+            value={correctionText}
+            onChange={handleCorrectionChange}
+            placeholder="Describe what the summary missed or got wrong..."
+            className="min-h-[80px] text-sm resize-none"
+            maxLength={CORRECTION_MAX_LENGTH}
+            aria-label="Correction text"
+          />
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">
+              {correctionText.length}/{CORRECTION_MAX_LENGTH}
+            </span>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleSkipCorrection}
+                disabled={isPending}
+              >
+                Skip
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleSubmitCorrection}
+                disabled={isPending}
+              >
+                {isPending ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Submitting...
+                  </>
+                ) : (
+                  'Submit'
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+});

--- a/frontend/hooks/useSummaryFeedback.ts
+++ b/frontend/hooks/useSummaryFeedback.ts
@@ -1,0 +1,163 @@
+/**
+ * Story P9-3.4: Summary Feedback Buttons
+ *
+ * Custom hooks for managing summary feedback using TanStack Query mutations.
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient, ApiError } from '@/lib/api-client';
+import type { ISummaryFeedback } from '@/types/event';
+
+interface SubmitSummaryFeedbackParams {
+  summaryId: string;
+  rating: 'positive' | 'negative';
+  correctionText?: string;
+}
+
+interface SummaryFeedbackResponse {
+  id: string;
+  summary_id: string;
+  rating: 'positive' | 'negative';
+  correction_text: string | null;
+  created_at: string;
+  updated_at: string | null;
+}
+
+/**
+ * Hook for fetching feedback for a summary
+ *
+ * @example
+ * const { data: feedback, isLoading } = useSummaryFeedback('123');
+ */
+export function useSummaryFeedback(summaryId: string) {
+  return useQuery<ISummaryFeedback | null, ApiError>({
+    queryKey: ['summaryFeedback', summaryId],
+    queryFn: async () => {
+      try {
+        const response = await fetch(
+          `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/v1/summaries/${summaryId}/feedback`
+        );
+        if (response.status === 404) {
+          return null;
+        }
+        if (!response.ok) {
+          throw new Error('Failed to fetch summary feedback');
+        }
+        return response.json();
+      } catch {
+        return null;
+      }
+    },
+    enabled: !!summaryId,
+    staleTime: 1000 * 60 * 5, // 5 minutes
+  });
+}
+
+/**
+ * Hook for submitting feedback on a summary
+ *
+ * @example
+ * const { mutate: submitFeedback, isPending } = useSubmitSummaryFeedback();
+ * submitFeedback({ summaryId: '123', rating: 'positive' });
+ */
+export function useSubmitSummaryFeedback() {
+  const queryClient = useQueryClient();
+
+  return useMutation<SummaryFeedbackResponse, ApiError, SubmitSummaryFeedbackParams>({
+    mutationFn: async ({ summaryId, rating, correctionText }) => {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/v1/summaries/${summaryId}/feedback`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            rating,
+            correction_text: correctionText ?? null,
+          }),
+        }
+      );
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({ detail: 'Failed to submit feedback' }));
+        throw new Error(error.detail || 'Failed to submit feedback');
+      }
+      return response.json();
+    },
+    onSuccess: (_data, variables) => {
+      // Invalidate feedback query to refresh data
+      queryClient.invalidateQueries({ queryKey: ['summaryFeedback', variables.summaryId] });
+      queryClient.invalidateQueries({ queryKey: ['summaries'] });
+    },
+  });
+}
+
+/**
+ * Hook for updating existing feedback on a summary
+ *
+ * @example
+ * const { mutate: updateFeedback, isPending } = useUpdateSummaryFeedback();
+ * updateFeedback({ summaryId: '123', rating: 'negative', correctionText: 'Missed an event' });
+ */
+export function useUpdateSummaryFeedback() {
+  const queryClient = useQueryClient();
+
+  return useMutation<SummaryFeedbackResponse, ApiError, SubmitSummaryFeedbackParams>({
+    mutationFn: async ({ summaryId, rating, correctionText }) => {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/v1/summaries/${summaryId}/feedback`,
+        {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            rating,
+            correction_text: correctionText ?? null,
+          }),
+        }
+      );
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({ detail: 'Failed to update feedback' }));
+        throw new Error(error.detail || 'Failed to update feedback');
+      }
+      return response.json();
+    },
+    onSuccess: (_data, variables) => {
+      // Invalidate feedback query to refresh data
+      queryClient.invalidateQueries({ queryKey: ['summaryFeedback', variables.summaryId] });
+      queryClient.invalidateQueries({ queryKey: ['summaries'] });
+    },
+  });
+}
+
+/**
+ * Hook for deleting feedback from a summary
+ *
+ * @example
+ * const { mutate: deleteFeedback, isPending } = useDeleteSummaryFeedback();
+ * deleteFeedback('123');
+ */
+export function useDeleteSummaryFeedback() {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, ApiError, string>({
+    mutationFn: async (summaryId) => {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/v1/summaries/${summaryId}/feedback`,
+        {
+          method: 'DELETE',
+        }
+      );
+      if (!response.ok && response.status !== 204) {
+        const error = await response.json().catch(() => ({ detail: 'Failed to delete feedback' }));
+        throw new Error(error.detail || 'Failed to delete feedback');
+      }
+    },
+    onSuccess: (_, summaryId) => {
+      // Invalidate feedback query to refresh data
+      queryClient.invalidateQueries({ queryKey: ['summaryFeedback', summaryId] });
+      queryClient.invalidateQueries({ queryKey: ['summaries'] });
+    },
+  });
+}

--- a/frontend/types/event.ts
+++ b/frontend/types/event.ts
@@ -410,3 +410,19 @@ export interface IEventFramesResponse {
   total_count: number;            // Total number of frames
   total_size_bytes: number;       // Total size of all frames in bytes
 }
+
+// ==============================================================================
+// Story P9-3.4: Summary Feedback Types
+// ==============================================================================
+
+/**
+ * Summary Feedback interface for user ratings on activity summaries
+ */
+export interface ISummaryFeedback {
+  id: string;                     // Feedback UUID
+  summary_id: string;             // Summary UUID
+  rating: 'positive' | 'negative';  // User rating
+  correction_text: string | null; // Optional correction text
+  created_at: string;             // ISO 8601 datetime
+  updated_at?: string | null;     // ISO 8601 datetime
+}


### PR DESCRIPTION
## Summary
- Add thumbs up/down feedback buttons to activity summaries (Story P9-3.4)
- Backend: SummaryFeedback model, API endpoints, Alembic migration
- Frontend: TypeScript types, React hooks, SummaryFeedbackButtons component
- 16 backend API tests covering all CRUD operations

## Changes
### Backend
- New `SummaryFeedback` model with one-to-one relationship to `ActivitySummary`
- Alembic migration `19df889882ef_add_summary_feedback_table.py`
- CRUD API endpoints: POST/GET/PUT/DELETE `/api/v1/summaries/{id}/feedback`
- Validation: 500 char max for correction text, unique constraint per summary

### Frontend
- `ISummaryFeedback` TypeScript interface
- `useSummaryFeedback` hooks (query, submit, update, delete mutations)
- `SummaryFeedbackButtons` component with thumbs up/down UI and correction modal
- Integration into summaries page

## Test plan
- [x] All 16 new summary feedback tests pass
- [x] Full backend test suite passes (3075 tests)
- [x] Frontend lint passes
- [x] Frontend build succeeds

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)