### PR TITLE
feat(settings): Add password change form to settings page (Story P10-1.1)

### DIFF
--- a/docs/sprint-artifacts/p10-1-1-implement-admin-password-change.context.xml
+++ b/docs/sprint-artifacts/p10-1-1-implement-admin-password-change.context.xml
@@ -1,0 +1,181 @@
+<story-context id="p10-1-1" v="1.0">
+  <metadata>
+    <epicId>P10-1</epicId>
+    <storyId>1</storyId>
+    <title>Implement Admin Password Change</title>
+    <status>ready-for-dev</status>
+    <generatedAt>2025-12-24</generatedAt>
+    <generator>BMAD Story Context Workflow</generator>
+    <sourceStoryPath>docs/sprint-artifacts/p10-1-1-implement-admin-password-change.md</sourceStoryPath>
+  </metadata>
+
+  <story>
+    <asA>user</asA>
+    <iWant>to change my admin password through the Settings UI</iWant>
+    <soThat>I can maintain account security</soThat>
+    <tasks>
+      <task id="1" status="done">Verify backend API exists - COMPLETE at backend/app/api/v1/auth.py:250-302</task>
+      <task id="2">Add API client method for password change - ALREADY EXISTS at frontend/lib/api-client.ts:955-960</task>
+      <task id="3">Create PasswordChangeForm component</task>
+      <task id="4">Integrate into Settings page</task>
+      <task id="5">Write tests</task>
+    </tasks>
+  </story>
+
+  <acceptanceCriteria>
+    <criterion id="1">Settings page has password change section (General tab or new Security section)</criterion>
+    <criterion id="2">Form has fields: Current Password, New Password, Confirm New Password</criterion>
+    <criterion id="3">Successful change shows toast "Password updated successfully" and session remains active</criterion>
+    <criterion id="4">Incorrect current password shows error "Current password is incorrect"</criterion>
+    <criterion id="5">Weak password shows requirements message</criterion>
+    <criterion id="6">Mismatched passwords show "Passwords do not match"</criterion>
+  </acceptanceCriteria>
+
+  <artifacts>
+    <docs>
+      <doc>
+        <path>docs/architecture/security-architecture.md</path>
+        <title>Security Architecture</title>
+        <section>Authentication Flow</section>
+        <snippet>JWT-based authentication with bcrypt password hashing. Passwords validated for 8+ chars, uppercase, number, special char.</snippet>
+      </doc>
+      <doc>
+        <path>docs/epics-phase10.md</path>
+        <title>Phase 10 Epics</title>
+        <section>Story P10-1.1</section>
+        <snippet>Implement admin password change functionality through Settings UI with current password verification.</snippet>
+      </doc>
+      <doc>
+        <path>docs/PRD-phase10.md</path>
+        <title>Phase 10 PRD</title>
+        <section>Bug Fix Requirements FR1-FR3</section>
+        <snippet>Users can change admin password through Settings UI with current password verification and clear feedback.</snippet>
+      </doc>
+    </docs>
+
+    <code>
+      <file>
+        <path>backend/app/api/v1/auth.py</path>
+        <kind>router</kind>
+        <symbol>change_password</symbol>
+        <lines>250-302</lines>
+        <reason>Backend endpoint already implemented - POST /api/v1/auth/change-password</reason>
+      </file>
+      <file>
+        <path>backend/app/schemas/auth.py</path>
+        <kind>schema</kind>
+        <symbol>ChangePasswordRequest</symbol>
+        <lines>32-35</lines>
+        <reason>Pydantic schema for password change request</reason>
+      </file>
+      <file>
+        <path>backend/app/utils/auth.py</path>
+        <kind>utility</kind>
+        <symbol>validate_password_strength</symbol>
+        <lines>N/A</lines>
+        <reason>Password validation logic - 8+ chars, uppercase, number, special char</reason>
+      </file>
+      <file>
+        <path>frontend/lib/api-client.ts</path>
+        <kind>api-client</kind>
+        <symbol>apiClient.auth.changePassword</symbol>
+        <lines>955-960</lines>
+        <reason>API client method already exists for calling change-password endpoint</reason>
+      </file>
+      <file>
+        <path>frontend/types/auth.ts</path>
+        <kind>types</kind>
+        <symbol>IChangePasswordRequest</symbol>
+        <lines>24-27</lines>
+        <reason>TypeScript interface for password change request</reason>
+      </file>
+      <file>
+        <path>frontend/app/settings/page.tsx</path>
+        <kind>page</kind>
+        <symbol>SettingsPage</symbol>
+        <lines>1-1331</lines>
+        <reason>Settings page where PasswordChangeForm should be integrated</reason>
+      </file>
+      <file>
+        <path>frontend/components/settings/AIProviders.tsx</path>
+        <kind>component</kind>
+        <symbol>AIProviders</symbol>
+        <lines>N/A</lines>
+        <reason>Reference component for settings form patterns with Card layout</reason>
+      </file>
+      <file>
+        <path>frontend/components/settings/MQTTSettings.tsx</path>
+        <kind>component</kind>
+        <symbol>MQTTSettings</symbol>
+        <lines>N/A</lines>
+        <reason>Reference component for form with password field patterns</reason>
+      </file>
+    </code>
+
+    <dependencies>
+      <frontend>
+        <package name="react" version="^19.0.0" />
+        <package name="react-hook-form" version="^7.54.2" />
+        <package name="@hookform/resolvers" version="^3.9.1" />
+        <package name="zod" version="^3.24.1" />
+        <package name="sonner" version="^1.7.1" />
+        <package name="lucide-react" version="^0.468.0" />
+        <package name="@radix-ui/react-*" purpose="shadcn/ui components" />
+      </frontend>
+      <backend>
+        <package name="fastapi" version="~0.115" />
+        <package name="bcrypt" purpose="password hashing" />
+        <package name="pydantic" version="^2.0" />
+      </backend>
+    </dependencies>
+  </artifacts>
+
+  <constraints>
+    <constraint>Follow existing settings component patterns (Card, react-hook-form, zod validation)</constraint>
+    <constraint>Use shadcn/ui components (Input, Button, Card, Label, Form)</constraint>
+    <constraint>Use toast from sonner for notifications</constraint>
+    <constraint>Password requirements: 8+ chars, 1 uppercase, 1 number, 1 special character</constraint>
+    <constraint>Must verify current password before allowing change</constraint>
+    <constraint>Session must remain active after password change</constraint>
+  </constraints>
+
+  <interfaces>
+    <interface>
+      <name>POST /api/v1/auth/change-password</name>
+      <kind>REST endpoint</kind>
+      <signature>Request: { current_password: string, new_password: string } → Response: { message: string }</signature>
+      <path>backend/app/api/v1/auth.py:250</path>
+    </interface>
+    <interface>
+      <name>apiClient.auth.changePassword</name>
+      <kind>TypeScript function</kind>
+      <signature>(request: IChangePasswordRequest) => Promise&lt;IMessageResponse&gt;</signature>
+      <path>frontend/lib/api-client.ts:955</path>
+    </interface>
+    <interface>
+      <name>IChangePasswordRequest</name>
+      <kind>TypeScript interface</kind>
+      <signature>{ current_password: string; new_password: string; }</signature>
+      <path>frontend/types/auth.ts:24</path>
+    </interface>
+  </interfaces>
+
+  <tests>
+    <standards>
+      Frontend tests use Vitest with React Testing Library. Tests are colocated in __tests__ directories.
+      Follow existing test patterns in frontend/__tests__/components/settings/*.test.tsx.
+      Test form validation, API error handling, and success flows.
+    </standards>
+    <locations>
+      <location>frontend/__tests__/components/settings/</location>
+    </locations>
+    <ideas>
+      <idea ac="2">Test form renders with all three password fields</idea>
+      <idea ac="3">Test successful password change shows success toast</idea>
+      <idea ac="4">Test API error for incorrect current password displays error message</idea>
+      <idea ac="5">Test client-side validation for weak passwords</idea>
+      <idea ac="6">Test confirm password mismatch validation</idea>
+      <idea ac="2">Test password visibility toggle functionality</idea>
+    </ideas>
+  </tests>
+</story-context>

--- a/docs/sprint-artifacts/p10-1-1-implement-admin-password-change.md
+++ b/docs/sprint-artifacts/p10-1-1-implement-admin-password-change.md
@@ -1,0 +1,146 @@
+# Story P10-1.1: Implement Admin Password Change
+
+Status: review
+
+## Story
+
+As a **user**,
+I want **to change my admin password through the Settings UI**,
+so that **I can maintain account security**.
+
+## Acceptance Criteria
+
+1. **Given** I navigate to Settings
+   **When** I view the settings tabs
+   **Then** I see a "Security" or "Account" tab (or section within General)
+
+2. **Given** I view the password section
+   **When** I look at the form
+   **Then** I see fields for: Current Password, New Password, Confirm New Password
+
+3. **Given** I enter my current password correctly and a valid new password
+   **When** I submit the form
+   **Then** my password is updated in the database
+   **And** a success toast appears "Password updated successfully"
+   **And** my session remains active
+
+4. **Given** I enter an incorrect current password
+   **When** I submit the form
+   **Then** an error message appears "Current password is incorrect"
+   **And** my password is not changed
+
+5. **Given** I enter a weak new password (missing requirements)
+   **When** I submit the form
+   **Then** an error message shows password requirements
+
+6. **Given** new password and confirm password don't match
+   **When** I try to submit
+   **Then** form validation prevents submission
+   **And** error message shows "Passwords do not match"
+
+## Tasks / Subtasks
+
+- [x] Task 1: Verify backend API exists (AC: all)
+  - [x] Subtask 1.1: Check `POST /api/v1/auth/change-password` endpoint
+  - [x] Subtask 1.2: Verify it validates current password
+  - [x] Subtask 1.3: Verify password strength validation
+  - [x] Result: Backend API exists and is complete at `backend/app/api/v1/auth.py:250-302`
+
+- [x] Task 2: Add API client method for password change (AC: 3-5)
+  - [x] Subtask 2.1: Add `changePassword` method to `apiClient.auth` in `lib/api-client.ts`
+  - [x] Subtask 2.2: Define request/response types
+  - [x] Result: API client method already existed at `frontend/lib/api-client.ts:955-960`
+
+- [x] Task 3: Create PasswordChangeForm component (AC: 1-6)
+  - [x] Subtask 3.1: Create `frontend/components/settings/PasswordChangeForm.tsx`
+  - [x] Subtask 3.2: Implement form with react-hook-form + zod validation
+  - [x] Subtask 3.3: Add current password, new password, confirm password fields
+  - [x] Subtask 3.4: Add password visibility toggles
+  - [x] Subtask 3.5: Add password strength indicator
+  - [x] Subtask 3.6: Handle API errors and display appropriate messages
+
+- [x] Task 4: Integrate into Settings page (AC: 1)
+  - [x] Subtask 4.1: Add to General tab or create Security section
+  - [x] Subtask 4.2: Wrap in Card component with appropriate header
+
+- [x] Task 5: Write tests (AC: all)
+  - [x] Subtask 5.1: Unit tests for PasswordChangeForm component
+  - [x] Subtask 5.2: Test validation (matching passwords, strength requirements)
+  - [x] Subtask 5.3: Test API error handling
+
+## Dev Notes
+
+### Backend API Already Complete
+
+The backend endpoint exists at `backend/app/api/v1/auth.py`:
+- `POST /api/v1/auth/change-password`
+- Request: `{ current_password: string, new_password: string }`
+- Response: `{ message: string }` on success, 400 on error
+- Password requirements: 8+ chars, uppercase, number, special char
+- Uses `validate_password_strength()` from `app/utils/auth.py`
+
+### Frontend Implementation Pattern
+
+Follow existing settings form patterns:
+- Use `react-hook-form` with `zodResolver` for validation
+- Use shadcn/ui components: Input, Button, Card, Label
+- Use `toast` from sonner for success/error notifications
+- Match styling of existing settings forms
+
+### Password Validation Schema (Zod)
+
+```typescript
+const passwordChangeSchema = z.object({
+  currentPassword: z.string().min(1, 'Current password is required'),
+  newPassword: z.string()
+    .min(8, 'Password must be at least 8 characters')
+    .regex(/[A-Z]/, 'Password must contain at least 1 uppercase letter')
+    .regex(/[0-9]/, 'Password must contain at least 1 number')
+    .regex(/[^A-Za-z0-9]/, 'Password must contain at least 1 special character'),
+  confirmPassword: z.string(),
+}).refine(data => data.newPassword === data.confirmPassword, {
+  message: 'Passwords do not match',
+  path: ['confirmPassword'],
+});
+```
+
+### Project Structure Notes
+
+- Component: `frontend/components/settings/PasswordChangeForm.tsx`
+- API client: `frontend/lib/api-client.ts` (add to `auth` namespace)
+- Settings page: `frontend/app/settings/page.tsx` (integrate component)
+- Tests: `frontend/__tests__/components/settings/PasswordChangeForm.test.tsx`
+
+### References
+
+- Backend endpoint: [Source: backend/app/api/v1/auth.py#250-302]
+- Auth schemas: [Source: backend/app/schemas/auth.py#32-35]
+- Settings page patterns: [Source: frontend/app/settings/page.tsx]
+- Security architecture: [Source: docs/architecture/security-architecture.md]
+
+## Dev Agent Record
+
+### Context Reference
+
+- docs/sprint-artifacts/p10-1-1-implement-admin-password-change.context.xml
+
+### Agent Model Used
+
+Claude Opus 4.5
+
+### Debug Log References
+
+### Completion Notes List
+
+- Backend API (`POST /api/v1/auth/change-password`) was already implemented at `backend/app/api/v1/auth.py:250-302`
+- Frontend API client method was already implemented at `frontend/lib/api-client.ts:955-960`
+- Created PasswordChangeForm component with Zod validation, password visibility toggles, and strength indicator
+- Integrated component into Settings page General tab
+- All 11 tests pass covering: field rendering, visibility toggles, validation errors, API submission, error handling, loading states, form clearing
+
+### File List
+
+- `frontend/components/settings/PasswordChangeForm.tsx` (created)
+- `frontend/app/settings/page.tsx` (modified - added PasswordChangeForm import and usage)
+- `frontend/__tests__/components/settings/PasswordChangeForm.test.tsx` (created)
+

--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -575,7 +575,7 @@ development_status:
   # Priority: P1 (Critical)
   # Focus: Admin password, infinite scroll, Today's Activity, UI fixes
   epic-p10-1: backlog
-  p10-1-1-implement-admin-password-change: backlog
+  p10-1-1-implement-admin-password-change: review
   p10-1-2-fix-events-page-infinite-scroll: backlog
   p10-1-3-fix-todays-activity-date-filtering: backlog
   p10-1-4-fix-events-page-button-positioning: backlog

--- a/frontend/__tests__/components/settings/PasswordChangeForm.test.tsx
+++ b/frontend/__tests__/components/settings/PasswordChangeForm.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * PasswordChangeForm Component Tests
+ * Story P10-1.1: Implement Admin Password Change
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PasswordChangeForm } from '@/components/settings/PasswordChangeForm';
+import { apiClient } from '@/lib/api-client';
+
+// Mock the API client
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    auth: {
+      changePassword: vi.fn(),
+    },
+  },
+}));
+
+// Mock sonner toast
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { toast } from 'sonner';
+
+describe('PasswordChangeForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all password fields', () => {
+    render(<PasswordChangeForm />);
+
+    expect(screen.getByPlaceholderText(/enter your current password/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/enter your new password/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/confirm your new password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /change password/i })).toBeInTheDocument();
+  });
+
+  it('shows password visibility toggle buttons', () => {
+    render(<PasswordChangeForm />);
+
+    // There should be 3 visibility toggle buttons (one per field)
+    const toggleButtons = screen.getAllByRole('button', { name: /show|hide/i });
+    expect(toggleButtons).toHaveLength(3);
+  });
+
+  it('toggles password visibility when clicking eye icon', async () => {
+    const user = userEvent.setup();
+    render(<PasswordChangeForm />);
+
+    const currentPasswordInput = screen.getByPlaceholderText(/enter your current password/i);
+    expect(currentPasswordInput).toHaveAttribute('type', 'password');
+
+    // Click the first toggle button (for current password)
+    const toggleButton = screen.getByRole('button', { name: /show current password/i });
+    await user.click(toggleButton);
+
+    expect(currentPasswordInput).toHaveAttribute('type', 'text');
+  });
+
+  it('shows validation error when current password is empty', async () => {
+    const user = userEvent.setup();
+    render(<PasswordChangeForm />);
+
+    const submitButton = screen.getByRole('button', { name: /^change password$/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/current password is required/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows validation error for weak password', async () => {
+    const user = userEvent.setup();
+    render(<PasswordChangeForm />);
+
+    const currentPasswordInput = screen.getByPlaceholderText(/enter your current password/i);
+    const newPasswordInput = screen.getByPlaceholderText(/enter your new password/i);
+    const confirmPasswordInput = screen.getByPlaceholderText(/confirm your new password/i);
+
+    await user.type(currentPasswordInput, 'currentpass');
+    await user.type(newPasswordInput, 'weak'); // Too short, no uppercase, no number, no special char
+    await user.type(confirmPasswordInput, 'weak');
+
+    const submitButton = screen.getByRole('button', { name: /^change password$/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/password must be at least 8 characters/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows validation error when passwords do not match', async () => {
+    const user = userEvent.setup();
+    render(<PasswordChangeForm />);
+
+    const currentPasswordInput = screen.getByPlaceholderText(/enter your current password/i);
+    const newPasswordInput = screen.getByPlaceholderText(/enter your new password/i);
+    const confirmPasswordInput = screen.getByPlaceholderText(/confirm your new password/i);
+
+    await user.type(currentPasswordInput, 'currentpass');
+    await user.type(newPasswordInput, 'ValidP@ss1');
+    await user.type(confirmPasswordInput, 'DifferentP@ss1');
+
+    const submitButton = screen.getByRole('button', { name: /^change password$/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/passwords do not match/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows password strength indicator when typing new password', async () => {
+    const user = userEvent.setup();
+    render(<PasswordChangeForm />);
+
+    const newPasswordInput = screen.getByPlaceholderText(/enter your new password/i);
+    await user.type(newPasswordInput, 'Test');
+
+    // Should show password requirements
+    await waitFor(() => {
+      expect(screen.getByText(/password requirements/i)).toBeInTheDocument();
+      expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument();
+      expect(screen.getByText(/at least 1 uppercase letter/i)).toBeInTheDocument();
+      expect(screen.getByText(/at least 1 number/i)).toBeInTheDocument();
+      expect(screen.getByText(/at least 1 special character/i)).toBeInTheDocument();
+    });
+  });
+
+  it('submits form successfully with valid data', async () => {
+    const user = userEvent.setup();
+    vi.mocked(apiClient.auth.changePassword).mockResolvedValueOnce({
+      message: 'Password changed successfully',
+    });
+
+    render(<PasswordChangeForm />);
+
+    const currentPasswordInput = screen.getByPlaceholderText(/enter your current password/i);
+    const newPasswordInput = screen.getByPlaceholderText(/enter your new password/i);
+    const confirmPasswordInput = screen.getByPlaceholderText(/confirm your new password/i);
+
+    await user.type(currentPasswordInput, 'OldPassword123!');
+    await user.type(newPasswordInput, 'NewPassword456!');
+    await user.type(confirmPasswordInput, 'NewPassword456!');
+
+    const submitButton = screen.getByRole('button', { name: /^change password$/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(apiClient.auth.changePassword).toHaveBeenCalledWith({
+        current_password: 'OldPassword123!',
+        new_password: 'NewPassword456!',
+      });
+      expect(toast.success).toHaveBeenCalledWith('Password updated successfully');
+    });
+  });
+
+  it('shows error toast when current password is incorrect', async () => {
+    const user = userEvent.setup();
+    vi.mocked(apiClient.auth.changePassword).mockRejectedValueOnce(
+      new Error('Current password is incorrect')
+    );
+
+    render(<PasswordChangeForm />);
+
+    const currentPasswordInput = screen.getByPlaceholderText(/enter your current password/i);
+    const newPasswordInput = screen.getByPlaceholderText(/enter your new password/i);
+    const confirmPasswordInput = screen.getByPlaceholderText(/confirm your new password/i);
+
+    await user.type(currentPasswordInput, 'WrongPassword123!');
+    await user.type(newPasswordInput, 'NewPassword456!');
+    await user.type(confirmPasswordInput, 'NewPassword456!');
+
+    const submitButton = screen.getByRole('button', { name: /^change password$/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Current password is incorrect');
+    });
+  });
+
+  it('shows loading state while submitting', async () => {
+    const user = userEvent.setup();
+    // Create a promise that we can control
+    let resolvePromise: (value: { message: string }) => void;
+    const promise = new Promise<{ message: string }>((resolve) => {
+      resolvePromise = resolve;
+    });
+    vi.mocked(apiClient.auth.changePassword).mockReturnValueOnce(promise);
+
+    render(<PasswordChangeForm />);
+
+    const currentPasswordInput = screen.getByPlaceholderText(/enter your current password/i);
+    const newPasswordInput = screen.getByPlaceholderText(/enter your new password/i);
+    const confirmPasswordInput = screen.getByPlaceholderText(/confirm your new password/i);
+
+    await user.type(currentPasswordInput, 'OldPassword123!');
+    await user.type(newPasswordInput, 'NewPassword456!');
+    await user.type(confirmPasswordInput, 'NewPassword456!');
+
+    const submitButton = screen.getByRole('button', { name: /^change password$/i });
+    await user.click(submitButton);
+
+    // Button should be disabled while loading
+    expect(submitButton).toBeDisabled();
+
+    // Resolve the promise to complete the test
+    resolvePromise!({ message: 'Success' });
+    await waitFor(() => {
+      expect(submitButton).not.toBeDisabled();
+    });
+  });
+
+  it('clears form after successful password change', async () => {
+    const user = userEvent.setup();
+    vi.mocked(apiClient.auth.changePassword).mockResolvedValueOnce({
+      message: 'Password changed successfully',
+    });
+
+    render(<PasswordChangeForm />);
+
+    const currentPasswordInput = screen.getByPlaceholderText(/enter your current password/i) as HTMLInputElement;
+    const newPasswordInput = screen.getByPlaceholderText(/enter your new password/i) as HTMLInputElement;
+    const confirmPasswordInput = screen.getByPlaceholderText(/confirm your new password/i) as HTMLInputElement;
+
+    await user.type(currentPasswordInput, 'OldPassword123!');
+    await user.type(newPasswordInput, 'NewPassword456!');
+    await user.type(confirmPasswordInput, 'NewPassword456!');
+
+    const submitButton = screen.getByRole('button', { name: /^change password$/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(currentPasswordInput.value).toBe('');
+      expect(newPasswordInput.value).toBe('');
+      expect(confirmPasswordInput.value).toBe('');
+    });
+  });
+});

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -63,6 +63,7 @@ import { PromptRefinementModal } from '@/components/settings/PromptRefinementMod
 import { CostWarningModal } from '@/components/settings/CostWarningModal';
 import { VideoStorageWarningModal } from '@/components/settings/VideoStorageWarningModal';
 import { FrameSamplingStrategySelector, type FrameSamplingStrategy } from '@/components/settings/FrameSamplingStrategySelector';
+import { PasswordChangeForm } from '@/components/settings/PasswordChangeForm';
 import { ControllerForm, type ControllerData, DeleteControllerDialog, DiscoveredCameraList } from '@/components/protect';
 import { useQuery } from '@tanstack/react-query';
 import type { AIProvider } from '@/types/settings';
@@ -631,6 +632,9 @@ export default function SettingsPage() {
                   </div>
                 </CardContent>
               </Card>
+
+              {/* Story P10-1.1: Password Change Form */}
+              <PasswordChangeForm />
 
               {/* Story P8-2.3: Cost Warning Modal */}
               <CostWarningModal

--- a/frontend/components/settings/PasswordChangeForm.tsx
+++ b/frontend/components/settings/PasswordChangeForm.tsx
@@ -1,0 +1,235 @@
+/**
+ * Password Change Form Component
+ * Story P10-1.1: Implement Admin Password Change
+ *
+ * Allows users to change their password through the Settings UI.
+ * Validates current password and new password requirements.
+ */
+
+'use client';
+
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { Eye, EyeOff, Loader2, Lock, CheckCircle2, XCircle } from 'lucide-react';
+
+import { apiClient } from '@/lib/api-client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+// Password validation schema matching backend requirements
+const passwordChangeSchema = z.object({
+  currentPassword: z.string().min(1, 'Current password is required'),
+  newPassword: z.string()
+    .min(8, 'Password must be at least 8 characters')
+    .regex(/[A-Z]/, 'Password must contain at least 1 uppercase letter')
+    .regex(/[0-9]/, 'Password must contain at least 1 number')
+    .regex(/[^A-Za-z0-9]/, 'Password must contain at least 1 special character'),
+  confirmPassword: z.string().min(1, 'Please confirm your new password'),
+}).refine(data => data.newPassword === data.confirmPassword, {
+  message: 'Passwords do not match',
+  path: ['confirmPassword'],
+});
+
+type PasswordChangeFormData = z.infer<typeof passwordChangeSchema>;
+
+// Password strength requirements for visual feedback
+const passwordRequirements = [
+  { regex: /.{8,}/, label: 'At least 8 characters' },
+  { regex: /[A-Z]/, label: 'At least 1 uppercase letter' },
+  { regex: /[0-9]/, label: 'At least 1 number' },
+  { regex: /[^A-Za-z0-9]/, label: 'At least 1 special character' },
+];
+
+export function PasswordChangeForm() {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showCurrentPassword, setShowCurrentPassword] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  const form = useForm<PasswordChangeFormData>({
+    resolver: zodResolver(passwordChangeSchema),
+    defaultValues: {
+      currentPassword: '',
+      newPassword: '',
+      confirmPassword: '',
+    },
+  });
+
+  const { register, handleSubmit, formState: { errors }, watch, reset } = form;
+  const newPassword = watch('newPassword');
+
+  const onSubmit = async (data: PasswordChangeFormData) => {
+    try {
+      setIsSubmitting(true);
+      await apiClient.auth.changePassword({
+        current_password: data.currentPassword,
+        new_password: data.newPassword,
+      });
+      toast.success('Password updated successfully');
+      reset(); // Clear form on success
+    } catch (error) {
+      // Handle specific error messages from backend
+      if (error instanceof Error) {
+        const message = error.message.toLowerCase();
+        if (message.includes('incorrect') || message.includes('current password')) {
+          toast.error('Current password is incorrect');
+        } else if (message.includes('8 characters') || message.includes('uppercase') ||
+                   message.includes('number') || message.includes('special')) {
+          toast.error(error.message);
+        } else {
+          toast.error('Failed to change password. Please try again.');
+        }
+      } else {
+        toast.error('Failed to change password. Please try again.');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Lock className="h-5 w-5 text-muted-foreground" />
+          <CardTitle>Change Password</CardTitle>
+        </div>
+        <CardDescription>
+          Update your account password. You&apos;ll need to enter your current password to confirm changes.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          {/* Current Password */}
+          <div className="space-y-2">
+            <Label htmlFor="currentPassword">Current Password</Label>
+            <div className="relative">
+              <Input
+                id="currentPassword"
+                type={showCurrentPassword ? 'text' : 'password'}
+                placeholder="Enter your current password"
+                autoComplete="current-password"
+                {...register('currentPassword')}
+                className={errors.currentPassword ? 'border-destructive' : ''}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                onClick={() => setShowCurrentPassword(!showCurrentPassword)}
+                aria-label={showCurrentPassword ? 'Hide current password' : 'Show current password'}
+              >
+                {showCurrentPassword ? (
+                  <EyeOff className="h-4 w-4 text-muted-foreground" />
+                ) : (
+                  <Eye className="h-4 w-4 text-muted-foreground" />
+                )}
+              </Button>
+            </div>
+            {errors.currentPassword && (
+              <p className="text-sm text-destructive">{errors.currentPassword.message}</p>
+            )}
+          </div>
+
+          {/* New Password */}
+          <div className="space-y-2">
+            <Label htmlFor="newPassword">New Password</Label>
+            <div className="relative">
+              <Input
+                id="newPassword"
+                type={showNewPassword ? 'text' : 'password'}
+                placeholder="Enter your new password"
+                autoComplete="new-password"
+                {...register('newPassword')}
+                className={errors.newPassword ? 'border-destructive' : ''}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                onClick={() => setShowNewPassword(!showNewPassword)}
+                aria-label={showNewPassword ? 'Hide new password' : 'Show new password'}
+              >
+                {showNewPassword ? (
+                  <EyeOff className="h-4 w-4 text-muted-foreground" />
+                ) : (
+                  <Eye className="h-4 w-4 text-muted-foreground" />
+                )}
+              </Button>
+            </div>
+            {errors.newPassword && (
+              <p className="text-sm text-destructive">{errors.newPassword.message}</p>
+            )}
+
+            {/* Password Strength Indicator */}
+            {newPassword && (
+              <div className="mt-2 space-y-1">
+                <p className="text-xs text-muted-foreground font-medium">Password requirements:</p>
+                <ul className="text-xs space-y-1">
+                  {passwordRequirements.map((req, index) => {
+                    const met = req.regex.test(newPassword);
+                    return (
+                      <li key={index} className={`flex items-center gap-1 ${met ? 'text-green-600' : 'text-muted-foreground'}`}>
+                        {met ? (
+                          <CheckCircle2 className="h-3 w-3" />
+                        ) : (
+                          <XCircle className="h-3 w-3" />
+                        )}
+                        {req.label}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
+          </div>
+
+          {/* Confirm New Password */}
+          <div className="space-y-2">
+            <Label htmlFor="confirmPassword">Confirm New Password</Label>
+            <div className="relative">
+              <Input
+                id="confirmPassword"
+                type={showConfirmPassword ? 'text' : 'password'}
+                placeholder="Confirm your new password"
+                autoComplete="new-password"
+                {...register('confirmPassword')}
+                className={errors.confirmPassword ? 'border-destructive' : ''}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                aria-label={showConfirmPassword ? 'Hide confirm password' : 'Show confirm password'}
+              >
+                {showConfirmPassword ? (
+                  <EyeOff className="h-4 w-4 text-muted-foreground" />
+                ) : (
+                  <Eye className="h-4 w-4 text-muted-foreground" />
+                )}
+              </Button>
+            </div>
+            {errors.confirmPassword && (
+              <p className="text-sm text-destructive">{errors.confirmPassword.message}</p>
+            )}
+          </div>
+
+          {/* Submit Button */}
+          <Button type="submit" disabled={isSubmitting} className="w-full sm:w-auto">
+            {isSubmitting && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            Change Password
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

- Implements password change functionality in the Settings page (Story P10-1.1)
- Creates PasswordChangeForm component with react-hook-form + Zod validation
- Adds password visibility toggles and real-time strength indicator
- Integrates with existing backend API (`POST /api/v1/auth/change-password`)
- Includes comprehensive test suite (11 tests passing)

## Changes

- `frontend/components/settings/PasswordChangeForm.tsx` - New component with form, validation, and error handling
- `frontend/app/settings/page.tsx` - Integrates PasswordChangeForm into General tab
- `frontend/__tests__/components/settings/PasswordChangeForm.test.tsx` - Unit tests

## Test Plan

- [x] Verify all form fields render correctly
- [x] Test password visibility toggles
- [x] Test validation for empty fields, weak passwords, non-matching passwords
- [x] Test successful password change API call
- [x] Test error handling for incorrect current password
- [x] Test loading state during submission
- [x] Test form clearing after successful change
- [x] All 11 tests pass

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)