### PR TITLE
feat(tunnel): Add Settings UI for Tunnel Configuration (Story P11-1.3)

### DIFF
--- a/docs/sprint-artifacts/P11-1-3.md
+++ b/docs/sprint-artifacts/P11-1-3.md
@@ -1,0 +1,132 @@
+# Story P11-1.3: Create Settings UI for Tunnel Configuration
+
+Status: done
+
+## Story
+
+As a user,
+I want to configure Cloudflare Tunnel from the Settings page,
+so that I can enable remote access without editing config files.
+
+## Acceptance Criteria
+
+1. AC-1.3.1: Settings > Integrations tab includes Tunnel section
+2. AC-1.3.2: Enable/disable toggle for tunnel
+3. AC-1.3.3: Secure input field for tunnel token (password type with show/hide toggle)
+4. AC-1.3.4: Status indicator shows connection state (disconnected, connecting, connected, error)
+5. AC-1.3.5: Test connection button validates setup and shows feedback
+
+## Tasks / Subtasks
+
+- [x] Task 1: Create TunnelSettings component (AC: 1.3.1, 1.3.2, 1.3.3, 1.3.4, 1.3.5)
+  - [x] 1.1: Create `frontend/components/settings/TunnelSettings.tsx` component
+  - [x] 1.2: Add enable/disable toggle with immediate save to backend
+  - [x] 1.3: Add secure token input field with show/hide password toggle
+  - [x] 1.4: Add status indicator badge (disconnected/connecting/connected/error)
+  - [x] 1.5: Add Test Connection button with loading state and toast feedback
+  - [x] 1.6: Display uptime, last connected, and reconnect count when connected
+  - [x] 1.7: Display error message when in error state
+- [x] Task 2: Integrate TunnelSettings into Settings page (AC: 1.3.1)
+  - [x] 2.1: Import TunnelSettings in `frontend/app/settings/page.tsx`
+  - [x] 2.2: Add TunnelSettings to Integrations tab alongside MQTTSettings and HomekitSettings
+  - [x] 2.3: Wrap with ErrorBoundary for resilient error handling
+- [x] Task 3: Add API client methods for tunnel operations
+  - [x] 3.1: Add `getTunnelStatus()` method to api-client.ts
+  - [x] 3.2: Add `startTunnel(token?: string)` method to api-client.ts
+  - [x] 3.3: Add `stopTunnel()` method to api-client.ts
+- [x] Task 4: Write component tests (AC: All)
+  - [x] 4.1: Create `frontend/__tests__/components/settings/TunnelSettings.test.tsx`
+  - [x] 4.2: Test toggle enable/disable behavior
+  - [x] 4.3: Test status indicator displays correctly for each state
+  - [x] 4.4: Test Test Connection button shows loading and success/error feedback
+
+## Dev Notes
+
+### Architecture Pattern
+This component follows the pattern established by similar settings components:
+- `MQTTSettings.tsx` - Integration toggle with form fields
+- `HomekitSettings.tsx` - Status display with diagnostics
+- `PushNotificationSettings.tsx` - Toggle with status indicators
+
+### Backend Endpoints (Already Implemented in P11-1.1, P11-1.2)
+The following endpoints are available from `backend/app/api/v1/system.py`:
+- `GET /api/v1/system/tunnel/status` - Returns TunnelStatusResponse
+- `POST /api/v1/system/tunnel/start` - Starts tunnel with optional token
+- `POST /api/v1/system/tunnel/stop` - Stops tunnel
+
+### TunnelStatusResponse Schema
+```typescript
+interface TunnelStatus {
+  status: 'disconnected' | 'connecting' | 'connected' | 'error';
+  is_connected: boolean;
+  is_running: boolean;
+  hostname: string | null;
+  error: string | null;
+  enabled: boolean;
+  uptime_seconds: number;
+  last_connected: string | null;
+  reconnect_count: number;
+}
+```
+
+### UI Components to Use
+- `Switch` from shadcn/ui for enable/disable toggle
+- `Input` with `type="password"` for token field
+- `Button` with eye icon for show/hide toggle
+- `Badge` or status dot for connection state indicator
+- `toast` from sonner for feedback messages
+- `Loader2` for loading spinner during connection test
+
+### Status Badge Colors
+- `disconnected`: gray (`bg-gray-400`)
+- `connecting`: yellow (`bg-yellow-500`) with pulse animation
+- `connected`: green (`bg-green-500`)
+- `error`: red (`bg-red-500`)
+
+### Testing Standards
+- Use Vitest + React Testing Library (established in P5-3.3)
+- Mock API calls with MSW or jest.fn()
+- Test all status states and user interactions
+
+### Project Structure Notes
+- Component path: `frontend/components/settings/TunnelSettings.tsx`
+- Test path: `frontend/__tests__/components/settings/TunnelSettings.test.tsx`
+- Settings page: `frontend/app/settings/page.tsx`
+- API client: `frontend/lib/api-client.ts`
+
+### References
+
+- [Source: docs/sprint-artifacts/tech-spec-epic-P11-1.md#APIs-and-Interfaces]
+- [Source: docs/epics-phase11.md#P11-1.3]
+- [Source: backend/app/api/v1/system.py:2041-2265] - Tunnel API endpoints
+- [Source: backend/app/services/tunnel_service.py] - TunnelService implementation
+- [Source: frontend/components/settings/MQTTSettings.tsx] - Similar pattern reference
+- [Source: frontend/components/settings/HomekitSettings.tsx] - Status display reference
+
+## Dev Agent Record
+
+### Context Reference
+
+<!-- Path(s) to story context XML will be added here by context workflow -->
+
+### Agent Model Used
+
+Claude Opus 4.5
+
+### Debug Log References
+
+### Completion Notes List
+
+- All acceptance criteria implemented and tested
+- 28 component tests pass covering all ACs
+- Frontend build successful
+- TunnelSettings component follows established patterns from MQTTSettings and HomekitSettings
+
+### File List
+
+- frontend/components/settings/TunnelSettings.tsx (new)
+- frontend/__tests__/components/settings/TunnelSettings.test.tsx (new)
+- frontend/lib/api-client.ts (modified - added tunnel API methods and types)
+- frontend/app/settings/page.tsx (modified - integrated TunnelSettings)
+- docs/sprint-artifacts/P11-1-3.md (new)
+

--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -661,7 +661,7 @@ development_status:
   epic-p11-1: contexted  # Tech spec: docs/sprint-artifacts/tech-spec-epic-P11-1.md
   p11-1-1-implement-cloudflare-tunnel-integration: done
   p11-1-2-add-tunnel-status-monitoring-and-auto-reconnect: done
-  p11-1-3-create-settings-ui-for-tunnel-configuration: backlog
+  p11-1-3-create-settings-ui-for-tunnel-configuration: done
   p11-1-4-document-tunnel-setup-in-user-guide: backlog
   epic-p11-1-retrospective: optional
 

--- a/frontend/__tests__/components/settings/TunnelSettings.test.tsx
+++ b/frontend/__tests__/components/settings/TunnelSettings.test.tsx
@@ -1,0 +1,509 @@
+/**
+ * TunnelSettings Component Tests (Story P11-1.3)
+ *
+ * Tests all acceptance criteria:
+ * - AC 1.3.1: Settings > Integrations tab includes Tunnel section
+ * - AC 1.3.2: Enable/disable toggle for tunnel
+ * - AC 1.3.3: Secure input field for tunnel token (password type with show/hide toggle)
+ * - AC 1.3.4: Status indicator shows connection state
+ * - AC 1.3.5: Test connection button validates setup and shows feedback
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TunnelSettings } from '@/components/settings/TunnelSettings';
+import { apiClient } from '@/lib/api-client';
+
+// Mock the API client
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    tunnel: {
+      getStatus: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+    },
+  },
+}));
+
+// Mock sonner toast
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Helper to create a fresh QueryClient for each test
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: 0,
+        gcTime: 0,
+      },
+    },
+  });
+}
+
+// Helper to render with providers
+function renderWithProviders(component: React.ReactNode) {
+  const queryClient = createTestQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      {component}
+    </QueryClientProvider>
+  );
+}
+
+// Default mock status response - disconnected
+const mockStatusDisconnected = {
+  status: 'disconnected' as const,
+  is_connected: false,
+  is_running: false,
+  hostname: null,
+  error: null,
+  enabled: false,
+  uptime_seconds: 0,
+  last_connected: null,
+  reconnect_count: 0,
+};
+
+// Mock status - connected
+const mockStatusConnected = {
+  status: 'connected' as const,
+  is_connected: true,
+  is_running: true,
+  hostname: 'argusai.example.com',
+  error: null,
+  enabled: true,
+  uptime_seconds: 3600,
+  last_connected: '2025-12-26T10:00:00Z',
+  reconnect_count: 2,
+};
+
+// Mock status - error
+const mockStatusError = {
+  status: 'error' as const,
+  is_connected: false,
+  is_running: false,
+  hostname: null,
+  error: 'Invalid tunnel token',
+  enabled: true,
+  uptime_seconds: 0,
+  last_connected: null,
+  reconnect_count: 0,
+};
+
+// Mock status - connecting
+const mockStatusConnecting = {
+  status: 'connecting' as const,
+  is_connected: false,
+  is_running: true,
+  hostname: null,
+  error: null,
+  enabled: true,
+  uptime_seconds: 0,
+  last_connected: null,
+  reconnect_count: 0,
+};
+
+describe('TunnelSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Set up default mocks
+    vi.mocked(apiClient.tunnel.getStatus).mockResolvedValue(mockStatusDisconnected);
+  });
+
+  describe('AC 1.3.1: Component renders in settings', () => {
+    it('renders the Tunnel settings card', async () => {
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Cloudflare Tunnel')).toBeInTheDocument();
+      });
+    });
+
+    it('shows loading state when fetching status', async () => {
+      // Create a promise that won't resolve immediately to catch loading state
+      let resolveStatus: (value: typeof mockStatusDisconnected) => void;
+      vi.mocked(apiClient.tunnel.getStatus).mockImplementation(
+        () => new Promise((resolve) => { resolveStatus = resolve; })
+      );
+
+      renderWithProviders(<TunnelSettings />);
+
+      // Should show a loading spinner
+      const spinner = document.querySelector('.animate-spin');
+      expect(spinner).toBeTruthy();
+
+      // Cleanup: resolve the promise
+      resolveStatus!(mockStatusDisconnected);
+    });
+
+    it('shows description text', async () => {
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Secure remote access without port forwarding')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('AC 1.3.2: Enable/disable toggle', () => {
+    it('renders enable toggle', async () => {
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/enable tunnel/i)).toBeInTheDocument();
+      });
+    });
+
+    it('toggle is off when tunnel is disabled', async () => {
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        const toggle = screen.getByLabelText(/enable tunnel/i);
+        expect(toggle).not.toBeChecked();
+      });
+    });
+
+    it('toggle is on when tunnel is enabled', async () => {
+      vi.mocked(apiClient.tunnel.getStatus).mockResolvedValue(mockStatusConnected);
+
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        const toggle = screen.getByLabelText(/enable tunnel/i);
+        expect(toggle).toBeChecked();
+      });
+    });
+
+    it('calls start API when toggling on', async () => {
+      const user = userEvent.setup();
+      vi.mocked(apiClient.tunnel.start).mockResolvedValue({
+        success: true,
+        message: 'Tunnel started',
+        status: mockStatusConnected,
+      });
+
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/enable tunnel/i)).toBeInTheDocument();
+      });
+
+      const toggle = screen.getByLabelText(/enable tunnel/i);
+      await user.click(toggle);
+
+      await waitFor(() => {
+        expect(apiClient.tunnel.start).toHaveBeenCalled();
+      });
+    });
+
+    it('calls stop API when toggling off', async () => {
+      const user = userEvent.setup();
+      vi.mocked(apiClient.tunnel.getStatus).mockResolvedValue(mockStatusConnected);
+      vi.mocked(apiClient.tunnel.stop).mockResolvedValue({
+        success: true,
+        message: 'Tunnel stopped',
+        status: mockStatusDisconnected,
+      });
+
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/enable tunnel/i)).toBeInTheDocument();
+      });
+
+      const toggle = screen.getByLabelText(/enable tunnel/i);
+      await user.click(toggle);
+
+      await waitFor(() => {
+        expect(apiClient.tunnel.stop).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('AC 1.3.3: Secure token input', () => {
+    it('renders token input field', async () => {
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/tunnel token/i)).toBeInTheDocument();
+      });
+    });
+
+    it('token field is password type by default', async () => {
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        const tokenInput = screen.getByLabelText(/tunnel token/i) as HTMLInputElement;
+        expect(tokenInput.type).toBe('password');
+      });
+    });
+
+    it('can toggle token visibility', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/tunnel token/i)).toBeInTheDocument();
+      });
+
+      // Token should initially be masked
+      const tokenInput = screen.getByLabelText(/tunnel token/i) as HTMLInputElement;
+      expect(tokenInput.type).toBe('password');
+
+      // Find the toggle button inside the token input container
+      const tokenContainer = tokenInput.parentElement;
+      const toggleButton = tokenContainer?.querySelector('button');
+
+      if (toggleButton) {
+        await user.click(toggleButton);
+
+        // After click, token should be visible
+        expect(tokenInput.type).toBe('text');
+      }
+    });
+
+    it('shows "Token configured" badge when hostname is set', async () => {
+      vi.mocked(apiClient.tunnel.getStatus).mockResolvedValue(mockStatusConnected);
+
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/token configured/i)).toBeInTheDocument();
+      });
+    });
+
+    it('shows placeholder when no token is configured', async () => {
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        const tokenInput = screen.getByLabelText(/tunnel token/i) as HTMLInputElement;
+        expect(tokenInput.placeholder).toContain('Enter Cloudflare Tunnel token');
+      });
+    });
+  });
+
+  describe('AC 1.3.4: Status indicator', () => {
+    it('shows disconnected status badge', async () => {
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Disconnected')).toBeInTheDocument();
+      });
+    });
+
+    it('shows connected status badge', async () => {
+      vi.mocked(apiClient.tunnel.getStatus).mockResolvedValue(mockStatusConnected);
+
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Connected')).toBeInTheDocument();
+      });
+    });
+
+    it('shows connecting status badge', async () => {
+      vi.mocked(apiClient.tunnel.getStatus).mockResolvedValue(mockStatusConnecting);
+
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Connecting')).toBeInTheDocument();
+      });
+    });
+
+    it('shows error status badge', async () => {
+      vi.mocked(apiClient.tunnel.getStatus).mockResolvedValue(mockStatusError);
+
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Error')).toBeInTheDocument();
+      });
+    });
+
+    it('shows error message when in error state', async () => {
+      vi.mocked(apiClient.tunnel.getStatus).mockResolvedValue(mockStatusError);
+
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Invalid tunnel token')).toBeInTheDocument();
+      });
+    });
+
+    it('shows hostname when connected', async () => {
+      vi.mocked(apiClient.tunnel.getStatus).mockResolvedValue(mockStatusConnected);
+
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByText('argusai.example.com')).toBeInTheDocument();
+      });
+    });
+
+    it('shows uptime when connected', async () => {
+      vi.mocked(apiClient.tunnel.getStatus).mockResolvedValue(mockStatusConnected);
+
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        // 3600 seconds = 1h 0m
+        expect(screen.getByText('1h 0m')).toBeInTheDocument();
+      });
+    });
+
+    it('shows reconnect count when connected', async () => {
+      vi.mocked(apiClient.tunnel.getStatus).mockResolvedValue(mockStatusConnected);
+
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByText('2')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('AC 1.3.5: Test connection button', () => {
+    it('renders test connection button', async () => {
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /test connection/i })).toBeInTheDocument();
+      });
+    });
+
+    it('calls start API when testing connection', async () => {
+      const user = userEvent.setup();
+      vi.mocked(apiClient.tunnel.start).mockResolvedValue({
+        success: true,
+        message: 'Connection test successful',
+        status: mockStatusConnected,
+      });
+
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /test connection/i })).toBeInTheDocument();
+      });
+
+      const button = screen.getByRole('button', { name: /test connection/i });
+      await user.click(button);
+
+      await waitFor(() => {
+        expect(apiClient.tunnel.start).toHaveBeenCalled();
+      });
+    });
+
+    it('shows loading state while testing', async () => {
+      const user = userEvent.setup();
+      let resolveStart: (value: unknown) => void;
+      vi.mocked(apiClient.tunnel.start).mockImplementation(
+        () => new Promise((resolve) => { resolveStart = resolve; })
+      );
+
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /test connection/i })).toBeInTheDocument();
+      });
+
+      const button = screen.getByRole('button', { name: /test connection/i });
+      await user.click(button);
+
+      // Should show testing state
+      await waitFor(() => {
+        expect(screen.getByText(/testing connection/i)).toBeInTheDocument();
+      });
+
+      // Cleanup
+      resolveStart!({
+        success: true,
+        message: 'Test complete',
+        status: mockStatusConnected,
+      });
+    });
+
+    it('uses token input when testing with new token', async () => {
+      const user = userEvent.setup();
+      vi.mocked(apiClient.tunnel.start).mockResolvedValue({
+        success: true,
+        message: 'Connection test successful',
+        status: mockStatusConnected,
+      });
+
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/tunnel token/i)).toBeInTheDocument();
+      });
+
+      // Enter a token
+      const tokenInput = screen.getByLabelText(/tunnel token/i);
+      await user.type(tokenInput, 'my-new-token');
+
+      // Click test connection
+      const button = screen.getByRole('button', { name: /test connection/i });
+      await user.click(button);
+
+      await waitFor(() => {
+        expect(apiClient.tunnel.start).toHaveBeenCalledWith('my-new-token');
+      });
+    });
+  });
+
+  describe('Additional functionality', () => {
+    it('shows info alert when disabled', async () => {
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/enable cloudflare tunnel/i)).toBeInTheDocument();
+      });
+    });
+
+    it('shows connected status panel when connected', async () => {
+      vi.mocked(apiClient.tunnel.getStatus).mockResolvedValue(mockStatusConnected);
+
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Tunnel Connected')).toBeInTheDocument();
+      });
+    });
+
+    it('clears token input after successful start', async () => {
+      const user = userEvent.setup();
+      vi.mocked(apiClient.tunnel.start).mockResolvedValue({
+        success: true,
+        message: 'Tunnel started',
+        status: mockStatusConnected,
+      });
+
+      renderWithProviders(<TunnelSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/tunnel token/i)).toBeInTheDocument();
+      });
+
+      // Enter a token
+      const tokenInput = screen.getByLabelText(/tunnel token/i) as HTMLInputElement;
+      await user.type(tokenInput, 'test-token');
+      expect(tokenInput.value).toBe('test-token');
+
+      // Toggle on
+      const toggle = screen.getByLabelText(/enable tunnel/i);
+      await user.click(toggle);
+
+      // Token should be cleared after successful start
+      await waitFor(() => {
+        expect(tokenInput.value).toBe('');
+      });
+    });
+  });
+});

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -57,6 +57,7 @@ import { AccuracyDashboard } from '@/components/settings/AccuracyDashboard';
 import { PushNotificationSettings } from '@/components/settings/PushNotificationSettings';
 import { MQTTSettings } from '@/components/settings/MQTTSettings';
 import { HomekitSettings } from '@/components/settings/HomekitSettings';
+import { TunnelSettings } from '@/components/settings/TunnelSettings';
 import { AnomalySettings } from '@/components/settings/AnomalySettings';
 import { MotionEventsExport } from '@/components/settings/MotionEventsExport';
 import { PromptRefinementModal } from '@/components/settings/PromptRefinementModal';
@@ -1274,8 +1275,11 @@ Keep the summary concise (2-3 paragraphs).`}
               </Card>
             </TabsContent>
 
-            {/* Integrations Tab - Story P4-2.4, P4-6.1 */}
+            {/* Integrations Tab - Story P4-2.4, P4-6.1, P11-1.3 */}
             <TabsContent value="integrations" className="space-y-4">
+              <ErrorBoundary context="Tunnel Settings">
+                <TunnelSettings />
+              </ErrorBoundary>
               <ErrorBoundary context="MQTT Settings">
                 <MQTTSettings />
               </ErrorBoundary>

--- a/frontend/components/settings/TunnelSettings.tsx
+++ b/frontend/components/settings/TunnelSettings.tsx
@@ -1,0 +1,396 @@
+/**
+ * TunnelSettings component (Story P11-1.3)
+ *
+ * Settings UI for Cloudflare Tunnel integration with:
+ * - Enable/disable toggle (AC-1.3.2)
+ * - Secure token input with show/hide (AC-1.3.3)
+ * - Status indicator (AC-1.3.4)
+ * - Test connection button (AC-1.3.5)
+ * - Uptime, last connected, reconnect count display
+ */
+
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import {
+  Cloud,
+  CloudOff,
+  Loader2,
+  Eye,
+  EyeOff,
+  RefreshCw,
+  CheckCircle2,
+  AlertTriangle,
+  ExternalLink,
+  Clock,
+  Activity,
+} from 'lucide-react';
+
+import { apiClient, type TunnelStatus } from '@/lib/api-client';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+/**
+ * Format seconds to human-readable uptime string
+ */
+function formatUptime(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  return `${hours}h ${minutes}m`;
+}
+
+/**
+ * Format ISO date to relative time
+ */
+function formatLastConnected(isoDate: string | null): string {
+  if (!isoDate) return 'Never';
+  const date = new Date(isoDate);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+
+  if (diffMins < 1) return 'Just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}d ago`;
+}
+
+export function TunnelSettings() {
+  const queryClient = useQueryClient();
+  const [showToken, setShowToken] = useState(false);
+  const [tokenInput, setTokenInput] = useState('');
+  const [isTesting, setIsTesting] = useState(false);
+
+  // Fetch tunnel status with polling
+  const statusQuery = useQuery({
+    queryKey: ['tunnel-status'],
+    queryFn: () => apiClient.tunnel.getStatus(),
+    refetchInterval: 5000, // Poll every 5 seconds
+  });
+
+  const status = statusQuery.data;
+
+  // Start tunnel mutation
+  const startMutation = useMutation({
+    mutationFn: (token?: string) => apiClient.tunnel.start(token),
+    onSuccess: (response) => {
+      if (response.success) {
+        toast.success('Tunnel started', {
+          description: response.message,
+        });
+        setTokenInput(''); // Clear token input after successful start
+      } else {
+        toast.error('Failed to start tunnel', {
+          description: response.message,
+        });
+      }
+      queryClient.invalidateQueries({ queryKey: ['tunnel-status'] });
+    },
+    onError: (error: Error) => {
+      toast.error('Failed to start tunnel', {
+        description: error.message,
+      });
+    },
+  });
+
+  // Stop tunnel mutation
+  const stopMutation = useMutation({
+    mutationFn: () => apiClient.tunnel.stop(),
+    onSuccess: (response) => {
+      if (response.success) {
+        toast.success('Tunnel stopped', {
+          description: response.message,
+        });
+      } else {
+        toast.error('Failed to stop tunnel', {
+          description: response.message,
+        });
+      }
+      queryClient.invalidateQueries({ queryKey: ['tunnel-status'] });
+    },
+    onError: (error: Error) => {
+      toast.error('Failed to stop tunnel', {
+        description: error.message,
+      });
+    },
+  });
+
+  // Handle toggle
+  const handleToggle = async (enabled: boolean) => {
+    if (enabled) {
+      // If we have a token input, use it; otherwise start with stored token
+      startMutation.mutate(tokenInput || undefined);
+    } else {
+      stopMutation.mutate();
+    }
+  };
+
+  // Test connection handler
+  const handleTestConnection = async () => {
+    setIsTesting(true);
+    try {
+      // Start with token to test, then check status
+      const result = await apiClient.tunnel.start(tokenInput || undefined);
+      if (result.success) {
+        toast.success('Connection test successful', {
+          description: result.message,
+        });
+      } else {
+        toast.error('Connection test failed', {
+          description: result.message,
+        });
+      }
+      queryClient.invalidateQueries({ queryKey: ['tunnel-status'] });
+    } catch (error) {
+      toast.error('Connection test failed', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    } finally {
+      setIsTesting(false);
+    }
+  };
+
+  // Status badge component
+  const getStatusBadge = () => {
+    if (statusQuery.isLoading) {
+      return (
+        <Badge variant="secondary">
+          <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+          Loading...
+        </Badge>
+      );
+    }
+
+    if (!status) {
+      return (
+        <Badge variant="secondary">
+          <CloudOff className="mr-1 h-3 w-3" />
+          Unknown
+        </Badge>
+      );
+    }
+
+    switch (status.status) {
+      case 'connected':
+        return (
+          <Badge variant="default" className="bg-green-600">
+            <CheckCircle2 className="mr-1 h-3 w-3" />
+            Connected
+          </Badge>
+        );
+      case 'connecting':
+        return (
+          <Badge variant="default" className="bg-yellow-500">
+            <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+            Connecting
+          </Badge>
+        );
+      case 'error':
+        return (
+          <Badge variant="destructive">
+            <AlertTriangle className="mr-1 h-3 w-3" />
+            Error
+          </Badge>
+        );
+      default:
+        return (
+          <Badge variant="secondary">
+            <CloudOff className="mr-1 h-3 w-3" />
+            Disconnected
+          </Badge>
+        );
+    }
+  };
+
+  if (statusQuery.isLoading && !status) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center py-8">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const isEnabled = status?.enabled || status?.is_running;
+  const isPending = startMutation.isPending || stopMutation.isPending;
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="space-y-1">
+            <CardTitle className="flex items-center gap-2">
+              <Cloud className="h-5 w-5" />
+              Cloudflare Tunnel
+            </CardTitle>
+            <CardDescription>
+              Secure remote access without port forwarding
+            </CardDescription>
+          </div>
+          {getStatusBadge()}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Enable Toggle */}
+        <div className="flex items-center justify-between rounded-lg border p-4">
+          <div className="space-y-0.5">
+            <Label htmlFor="tunnel-enabled" className="text-base font-medium">
+              Enable Tunnel
+            </Label>
+            <p className="text-sm text-muted-foreground">
+              Connect ArgusAI to your Cloudflare Tunnel for remote access
+            </p>
+          </div>
+          <Switch
+            id="tunnel-enabled"
+            checked={isEnabled}
+            onCheckedChange={handleToggle}
+            disabled={isPending}
+          />
+        </div>
+
+        {/* Token Input */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="tunnel-token">Tunnel Token</Label>
+            {status?.hostname && (
+              <Badge variant="outline" className="text-xs">
+                <CheckCircle2 className="mr-1 h-3 w-3" />
+                Token configured
+              </Badge>
+            )}
+          </div>
+          <div className="relative">
+            <Input
+              id="tunnel-token"
+              type={showToken ? 'text' : 'password'}
+              placeholder={status?.hostname ? '••••••••••••••••' : 'Enter Cloudflare Tunnel token'}
+              value={tokenInput}
+              onChange={(e) => setTokenInput(e.target.value)}
+              className="pr-10"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+              onClick={() => setShowToken(!showToken)}
+            >
+              {showToken ? (
+                <EyeOff className="h-4 w-4 text-muted-foreground" />
+              ) : (
+                <Eye className="h-4 w-4 text-muted-foreground" />
+              )}
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Get your token from the Cloudflare Zero Trust dashboard. Leave empty to use stored token.
+          </p>
+        </div>
+
+        {/* Test Connection Button */}
+        <Button
+          type="button"
+          variant="outline"
+          onClick={handleTestConnection}
+          disabled={isTesting || isPending}
+          className="w-full"
+        >
+          {isTesting ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Testing connection...
+            </>
+          ) : (
+            <>
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Test Connection
+            </>
+          )}
+        </Button>
+
+        {/* Connected Status Details */}
+        {status?.is_connected && (
+          <div className="rounded-lg bg-muted/50 p-4 space-y-3">
+            <div className="flex items-center gap-2">
+              <Cloud className="h-4 w-4 text-green-600" />
+              <span className="font-medium text-green-600">Tunnel Connected</span>
+            </div>
+
+            {/* Hostname */}
+            {status.hostname && (
+              <div className="flex items-center gap-2 text-sm">
+                <ExternalLink className="h-4 w-4 text-muted-foreground" />
+                <a
+                  href={`https://${status.hostname}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  {status.hostname}
+                </a>
+              </div>
+            )}
+
+            {/* Stats Grid */}
+            <div className="grid grid-cols-3 gap-4 text-sm">
+              <div className="flex items-center gap-2">
+                <Clock className="h-4 w-4 text-muted-foreground" />
+                <div>
+                  <span className="text-muted-foreground">Uptime:</span>
+                  <span className="ml-1 font-medium">{formatUptime(status.uptime_seconds)}</span>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Activity className="h-4 w-4 text-muted-foreground" />
+                <div>
+                  <span className="text-muted-foreground">Last:</span>
+                  <span className="ml-1 font-medium">{formatLastConnected(status.last_connected)}</span>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <RefreshCw className="h-4 w-4 text-muted-foreground" />
+                <div>
+                  <span className="text-muted-foreground">Reconnects:</span>
+                  <span className="ml-1 font-medium">{status.reconnect_count}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Error Display */}
+        {status?.status === 'error' && status.error && (
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertDescription>{status.error}</AlertDescription>
+          </Alert>
+        )}
+
+        {/* Info when disabled */}
+        {!isEnabled && !status?.is_connected && (
+          <Alert>
+            <Cloud className="h-4 w-4" />
+            <AlertDescription>
+              Enable Cloudflare Tunnel to access ArgusAI from anywhere without port forwarding.
+              You&apos;ll need a Cloudflare account and a tunnel token from the Zero Trust dashboard.
+            </AlertDescription>
+          </Alert>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -2217,6 +2217,41 @@ export const apiClient = {
       });
     },
   },
+
+  // ============================================================================
+  // Cloudflare Tunnel (Story P11-1.3)
+  // ============================================================================
+  tunnel: {
+    /**
+     * Get Cloudflare Tunnel status
+     * @returns Current tunnel status
+     */
+    getStatus: async (): Promise<TunnelStatus> => {
+      return apiFetch('/system/tunnel/status');
+    },
+
+    /**
+     * Start Cloudflare Tunnel
+     * @param token Optional tunnel token (uses stored if not provided)
+     * @returns Action result with updated status
+     */
+    start: async (token?: string): Promise<TunnelActionResponse> => {
+      return apiFetch('/system/tunnel/start', {
+        method: 'POST',
+        body: token ? JSON.stringify({ token }) : undefined,
+      });
+    },
+
+    /**
+     * Stop Cloudflare Tunnel
+     * @returns Action result with updated status
+     */
+    stop: async (): Promise<TunnelActionResponse> => {
+      return apiFetch('/system/tunnel/stop', {
+        method: 'POST',
+      });
+    },
+  },
 };
 
 // ============================================================================
@@ -2307,4 +2342,26 @@ export interface SummaryFeedbackResponse {
   correction_text: string | null;
   created_at: string;
   updated_at: string | null;
+}
+
+// ============================================================================
+// Cloudflare Tunnel Types (Story P11-1.3)
+// ============================================================================
+
+export interface TunnelStatus {
+  status: 'disconnected' | 'connecting' | 'connected' | 'error';
+  is_connected: boolean;
+  is_running: boolean;
+  hostname: string | null;
+  error: string | null;
+  enabled: boolean;
+  uptime_seconds: number;
+  last_connected: string | null;
+  reconnect_count: number;
+}
+
+export interface TunnelActionResponse {
+  success: boolean;
+  message: string;
+  status?: TunnelStatus;
 }


### PR DESCRIPTION
## Summary
- Create TunnelSettings component with enable/disable toggle
- Add secure token input with show/hide toggle
- Add status indicator (disconnected/connecting/connected/error)
- Add Test Connection button with loading state and toast feedback
- Display uptime, last connected, and reconnect count when connected
- Integrate TunnelSettings into Settings > Integrations tab
- Add tunnel API methods (getStatus, start, stop) to api-client.ts
- Add 28 component tests covering all acceptance criteria

## Acceptance Criteria
- [x] AC-1.3.1: Settings > Integrations tab includes Tunnel section
- [x] AC-1.3.2: Enable/disable toggle for tunnel
- [x] AC-1.3.3: Secure input field for tunnel token (password type with show/hide toggle)
- [x] AC-1.3.4: Status indicator shows connection state (disconnected, connecting, connected, error)
- [x] AC-1.3.5: Test connection button validates setup and shows feedback

## Test Plan
- [x] Frontend build succeeds
- [x] 28 component tests pass for TunnelSettings
- [ ] Manual testing: Navigate to Settings > Integrations, verify TunnelSettings appears
- [ ] Manual testing: Toggle enable/disable and verify API calls
- [ ] Manual testing: Test token input show/hide toggle
- [ ] Manual testing: Verify status indicator reflects backend state
- [ ] Manual testing: Test connection button shows loading and feedback

## Related
- Epic: P11-1 Cloudflare Tunnel Integration
- Depends on: P11-1.1 (done), P11-1.2 (done) - Backend implementation
- Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)