### PR TITLE
fix(docs-site): Fix broken links in cloudflare-tunnel page

### DIFF
--- a/docs-site/docs/integrations/cloudflare-tunnel.md
+++ b/docs-site/docs/integrations/cloudflare-tunnel.md
@@ -259,6 +259,6 @@ Add authentication before users can access ArgusAI:
 
 ## Related Documentation
 
-- [Full Tunnel Setup Guide](/docs/guides/tunnel-setup.md) - Comprehensive reference
-- [Cloud Relay Architecture](/docs/architecture/cloud-relay-architecture.md) - Technical design
+- [Full Tunnel Setup Guide](https://github.com/bbengt1/ArgusAI/blob/main/docs/guides/tunnel-setup.md) - Comprehensive reference
+- [Cloud Relay Architecture](https://github.com/bbengt1/ArgusAI/blob/main/docs/architecture/cloud-relay-architecture.md) - Technical design
 - [Cloudflare Tunnel Docs](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) - Official documentation


### PR DESCRIPTION
## Summary

Fix broken links that caused GitHub Pages build to fail.

## Changes

Update links in `docs-site/docs/integrations/cloudflare-tunnel.md` to point to GitHub repository instead of non-existent docs-site paths:
- Full Tunnel Setup Guide → `github.com/.../docs/guides/tunnel-setup.md`
- Cloud Relay Architecture → `github.com/.../docs/architecture/cloud-relay-architecture.md`

## Error Fixed

```
Broken link on source page path = /ArgusAI/docs/integrations/cloudflare-tunnel:
   -> linking to /ArgusAI/docs/guides/tunnel-setup.md
   -> linking to /ArgusAI/docs/architecture/cloud-relay-architecture.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)