### PR TITLE
feat(events): Complete Epic P11-5 - Platform Polish & Documentation

### DIFF
--- a/docs/sprint-artifacts/P11-5-4.md
+++ b/docs/sprint-artifacts/P11-5-4.md
@@ -1,0 +1,47 @@
+# Story P11-5.4: Add Export Events to CSV Button
+
+## Status: DONE
+
+## Story
+**As a** user viewing my events timeline
+**I want** to export filtered events to CSV
+**So that** I can analyze my event data in spreadsheets or other tools
+
+## Acceptance Criteria
+- [x] Export button visible on Events page when events exist
+- [x] Export uses current filters (date range, camera)
+- [x] CSV downloads with appropriate filename
+- [x] Loading state shown during export
+- [x] Error handling with toast notifications
+
+## Implementation Notes
+
+### Frontend Changes
+1. **lib/api-client.ts** - Added `events.exportCsv()` method that:
+   - Calls `/api/v1/events/export?format=csv` with optional filters
+   - Returns a Blob for file download
+   - Uses existing auth headers
+
+2. **app/events/page.tsx** - Added Export button:
+   - Download icon from lucide-react
+   - Shows loading spinner during export
+   - Creates temporary download link for CSV
+   - Uses current date range and camera filters
+   - Toast notifications for success/failure
+
+### Backend (Already Existed)
+The `/api/v1/events/export` endpoint was already implemented in Phase 3, supporting:
+- CSV format
+- Date range filters (start_date, end_date)
+- Camera filter (camera_id)
+- Streaming response for large exports
+
+## Technical Details
+- Button appears next to Refresh button
+- Disabled during export with spinner
+- Filename format: `events-YYYY-MM-DD.csv`
+- Respects authentication via `getAuthHeaders()`
+
+## Dependencies
+- lucide-react (Download icon)
+- sonner (toast notifications)

--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -699,9 +699,9 @@ development_status:
   # Epic P11-5: Platform Polish & Documentation
   # Priority: P3
   # Focus: Performance, UX, and documentation
-  epic-p11-5: contexted  # Tech spec: docs/sprint-artifacts/tech-spec-epic-P11-5.md
-  p11-5-1-optimize-camera-list-performance: backlog
-  p11-5-2-add-test-connection-before-camera-save: backlog
-  p11-5-3-update-github-pages-documentation-site: backlog
-  p11-5-4-add-export-motion-events-to-csv: backlog
+  epic-p11-5: done  # Tech spec: docs/sprint-artifacts/tech-spec-epic-P11-5.md
+  p11-5-1-optimize-camera-list-performance: done  # Already complete from Phase 6 (P6-1.2, P6-1.3, P6-1.4)
+  p11-5-2-add-test-connection-before-camera-save: done  # Already complete from Phase 6 (P6-1.1)
+  p11-5-3-update-github-pages-documentation-site: done  # Documentation site already fully built
+  p11-5-4-add-export-motion-events-to-csv: done  # Added Export button to Events page
   epic-p11-5-retrospective: optional

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -628,6 +628,32 @@ export const apiClient = {
     getFrameUrl: (eventId: string, frameNumber: number): string => {
       return `${API_V1_PREFIX}/events/${eventId}/frames/${frameNumber}`;
     },
+
+    /**
+     * Export events to CSV format (Story P11-5.4)
+     * @param filters Optional filters (date range, camera)
+     * @returns Blob containing CSV file
+     */
+    exportCsv: async (filters?: {
+      start_date?: string;
+      end_date?: string;
+      camera_id?: string;
+    }): Promise<Blob> => {
+      const params = new URLSearchParams();
+      params.set('format', 'csv');
+      if (filters?.start_date) params.set('start_date', filters.start_date);
+      if (filters?.end_date) params.set('end_date', filters.end_date);
+      if (filters?.camera_id) params.set('camera_id', filters.camera_id);
+      const queryString = params.toString();
+      const response = await fetch(`${API_BASE_URL}${API_V1_PREFIX}/events/export?${queryString}`, {
+        method: 'GET',
+        headers: getAuthHeaders(),
+      });
+      if (!response.ok) {
+        throw new ApiError('Failed to export events', response.status);
+      }
+      return response.blob();
+    },
   },
 
   settings: {


### PR DESCRIPTION
## Summary
- Add Export to CSV button on Events page (Story P11-5.4)
- Mark epic P11-5 as complete in sprint-status.yaml

**Note**: Stories P11-5.1, P11-5.2, and P11-5.3 were already complete from previous phases:
- **P11-5.1**: Camera list performance optimization was completed in Phase 6 (Stories P6-1.2, P6-1.3, P6-1.4) with React.memo, virtual scrolling, and React Query caching
- **P11-5.2**: Test connection before camera save was completed in Phase 6 (Story P6-1.1) with /api/v1/cameras/test endpoint and full UI in CameraForm
- **P11-5.3**: GitHub Pages documentation site was already fully built with Docusaurus, including 25+ docs pages covering installation, configuration, features, API reference, and integrations

## Changes
- `frontend/lib/api-client.ts` - Added `events.exportCsv()` method
- `frontend/app/events/page.tsx` - Added Export button with loading state
- `docs/sprint-artifacts/sprint-status.yaml` - Mark P11-5 stories as done
- `docs/sprint-artifacts/P11-5-4.md` - Story completion documentation

## Test plan
- [ ] Navigate to Events page with events visible
- [ ] Click Export button and verify CSV downloads
- [ ] Apply filters (date range, camera) and export - verify filters apply
- [ ] Verify loading spinner shows during export
- [ ] Test error handling by blocking API - verify toast shows error

🤖 Generated with [Claude Code](https://claude.com/claude-code)