### PR TITLE
feat(P13-2): Cloud Relay - Add tunnel connectivity test endpoint

### DIFF
--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -782,12 +782,14 @@ development_status:
   # Epic P13-2: Cloud Relay
   # Priority: P3
   # Focus: Remote access via Cloudflare Tunnel
-  epic-p13-2: backlog  # Tech spec: docs/sprint-artifacts/tech-spec-epic-P13-2.md
-  p13-2-1-add-tunnel-configuration-to-settings: backlog
-  p13-2-2-implement-cloudflare-tunnel-service: backlog
-  p13-2-3-add-tunnel-status-endpoint: backlog
-  p13-2-4-implement-tunnel-connectivity-test: backlog
-  p13-2-5-websocket-relay-support: backlog
+  # Status: COMPLETE - All functionality already implemented in Phase 11
+  #         P13-2.4 test endpoint added 2025-12-28
+  epic-p13-2: done  # Tech spec: docs/sprint-artifacts/tech-spec-epic-P13-2.md
+  p13-2-1-add-tunnel-configuration-to-settings: done  # TunnelSettings.tsx from P11-1.3
+  p13-2-2-implement-cloudflare-tunnel-service: done  # Auto-start in main.py from P11-1.1
+  p13-2-3-add-tunnel-status-endpoint: done  # /tunnel/status with uptime from P11-1.2
+  p13-2-4-implement-tunnel-connectivity-test: done  # Added POST /tunnel/test endpoint
+  p13-2-5-websocket-relay-support: done  # Native Cloudflare Tunnel feature (no code needed)
   epic-p13-2-retrospective: optional
 
   # Epic P13-3: Entity Reprocessing

--- a/frontend/components/settings/TunnelSettings.tsx
+++ b/frontend/components/settings/TunnelSettings.tsx
@@ -137,20 +137,34 @@ export function TunnelSettings() {
     }
   };
 
-  // Test connection handler
+  // Test connection handler (Story P13-2.4)
   const handleTestConnection = async () => {
     setIsTesting(true);
     try {
-      // Start with token to test, then check status
-      const result = await apiClient.tunnel.start(tokenInput || undefined);
-      if (result.success) {
-        toast.success('Connection test successful', {
-          description: result.message,
-        });
+      // If token is provided, use dedicated test endpoint (doesn't persist config)
+      if (tokenInput) {
+        const result = await apiClient.tunnel.test(tokenInput);
+        if (result.success) {
+          toast.success('Connection test successful', {
+            description: `Connected to ${result.hostname} in ${result.latency_ms}ms`,
+          });
+        } else {
+          toast.error('Connection test failed', {
+            description: result.error || 'Unknown error',
+          });
+        }
       } else {
-        toast.error('Connection test failed', {
-          description: result.message,
-        });
+        // No token provided - start with saved token
+        const result = await apiClient.tunnel.start();
+        if (result.success) {
+          toast.success('Connection test successful', {
+            description: result.message,
+          });
+        } else {
+          toast.error('Connection test failed', {
+            description: result.message,
+          });
+        }
       }
       queryClient.invalidateQueries({ queryKey: ['tunnel-status'] });
     } catch (error) {

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -2482,6 +2482,19 @@ export const apiClient = {
         method: 'POST',
       });
     },
+
+    /**
+     * Test Cloudflare Tunnel connectivity (Story P13-2.4)
+     * Tests connection without persisting configuration
+     * @param token Tunnel token to test
+     * @returns Test result with latency and hostname
+     */
+    test: async (token: string): Promise<TunnelTestResponse> => {
+      return apiFetch('/system/tunnel/test', {
+        method: 'POST',
+        body: JSON.stringify({ token }),
+      });
+    },
   },
 };
 
@@ -2595,4 +2608,12 @@ export interface TunnelActionResponse {
   success: boolean;
   message: string;
   status?: TunnelStatus;
+}
+
+// Story P13-2.4: Tunnel connectivity test response
+export interface TunnelTestResponse {
+  success: boolean;
+  error: string | null;
+  latency_ms: number | null;
+  hostname: string | null;
 }


### PR DESCRIPTION
## Summary

Epic P13-2: Cloud Relay - Complete implementation

Analysis revealed that most of Epic P13-2 functionality was already implemented in Phase 11 (P11-1.x stories):
- **P13-2.1**: TunnelSettings.tsx UI exists from P11-1.3
- **P13-2.2**: Auto-start on boot already in main.py from P11-1.1  
- **P13-2.3**: Enhanced status endpoint with uptime/reconnect from P11-1.2
- **P13-2.5**: WebSocket relay is a native Cloudflare Tunnel feature (no code needed)

The only missing piece was **P13-2.4**: A dedicated test endpoint that doesn't persist configuration.

### Changes

- Add `POST /api/v1/system/tunnel/test` endpoint
  - Tests tunnel connectivity without persisting token
  - Returns `latency_ms` and `hostname` on success
  - Restores previous tunnel state after test
- Update `TunnelSettings.tsx` to use dedicated test endpoint when a token is provided
- Add `TunnelTestResponse` type and `test()` method to api-client
- Update sprint-status.yaml to mark all P13-2 stories as done

### API Contract

```json
POST /api/v1/system/tunnel/test
{
  "token": "your-tunnel-token"
}

Response:
{
  "success": true,
  "error": null,
  "latency_ms": 2500,
  "hostname": "my-tunnel.trycloudflare.com"
}
```

## Test plan

- [ ] Start backend and verify new `/tunnel/test` endpoint appears in OpenAPI docs
- [ ] Test endpoint with valid Cloudflare tunnel token - should return hostname and latency
- [ ] Test endpoint with invalid token - should return error message
- [ ] Verify existing tunnel state is restored after test
- [ ] Test frontend "Test Connection" button with new token input

🤖 Generated with [Claude Code](https://claude.com/claude-code)