### PR TITLE
feat(security): Disable debug endpoints by default (P14-1.2)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,12 @@ ENCRYPTION_KEY=your-generated-fernet-key-here
 DEBUG=True
 LOG_LEVEL=INFO
 
+# Debug Endpoints (Story P14-1.2)
+# SECURITY WARNING: Only enable for development - exposes sensitive info!
+# When enabled, /debug/ai-keys shows API key structure and /debug/network
+# exposes internal network topology. NEVER enable in production.
+DEBUG_ENDPOINTS_ENABLED=false
+
 # API Configuration
 API_V1_PREFIX=/api/v1
 CORS_ORIGINS=http://localhost:3000,http://localhost:8000

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -23,6 +23,10 @@ class Settings(BaseSettings):
     DEBUG: bool = False
     LOG_LEVEL: str = "INFO"
 
+    # Debug Endpoints (Story P14-1.2)
+    # SECURITY WARNING: Only enable for development - exposes sensitive info
+    DEBUG_ENDPOINTS_ENABLED: bool = False
+
     # API
     API_V1_PREFIX: str = "/api/v1"
     # Stored as string to avoid pydantic-settings JSON parsing; use cors_origins_list property

--- a/docs/sprint-artifacts/P14-1-2.md
+++ b/docs/sprint-artifacts/P14-1-2.md
@@ -1,0 +1,99 @@
+# Story P14-1.2: Remove or Secure Debug Endpoints
+
+Status: done
+
+## Story
+
+As a **security-conscious administrator**,
+I want debug endpoints to be disabled by default,
+so that sensitive internal information is not exposed to unauthorized network users.
+
+## Acceptance Criteria
+
+1. **AC1**: `GET /api/v1/system/debug/ai-keys` returns 404 when `DEBUG_ENDPOINTS_ENABLED=false` (default)
+2. **AC2**: `GET /api/v1/system/debug/network` returns 404 when `DEBUG_ENDPOINTS_ENABLED=false` (default)
+3. **AC3**: Debug endpoints are not visible in OpenAPI/Swagger documentation when disabled
+4. **AC4**: `DEBUG_ENDPOINTS_ENABLED` defaults to `false`
+5. **AC5**: `.env.example` documents the new variable with security warning
+6. **AC6**: When `DEBUG_ENDPOINTS_ENABLED=true`, endpoints work as before (for development)
+
+## Tasks / Subtasks
+
+- [x] Task 1: Add `DEBUG_ENDPOINTS_ENABLED` setting to config.py (AC: 4)
+  - [x] Add boolean field with default=False
+  - [x] Add descriptive comment about security implications
+- [x] Task 2: Conditionally register debug endpoints (AC: 1, 2, 3, 6)
+  - [x] Move endpoint definitions inside conditional block
+  - [x] Use `include_in_schema=False` to hide from OpenAPI when enabled
+  - [x] Ensure endpoints return 404 (not registered at all) when disabled
+- [x] Task 3: Update `.env.example` (AC: 5)
+  - [x] Add DEBUG_ENDPOINTS_ENABLED=false with security warning
+- [x] Task 4: Add unit tests for debug endpoint security (AC: 1, 2, 3)
+  - [x] Test endpoints return 404 when disabled
+  - [x] Test endpoints not in OpenAPI schema when disabled
+  - [x] (Test for enabled mode requires separate test with env var override - not practical for CI)
+
+## Dev Notes
+
+### Technical Context
+
+The debug endpoints at `backend/app/api/v1/system.py:53-119` expose sensitive information:
+- `/debug/ai-keys` - Shows API key storage structure, encrypted prefixes, lengths
+- `/debug/network` - Exposes internal IP addresses (10.0.1.254), RTSP URLs, credentials
+
+**Current Security Issues:**
+1. Endpoints are always available (no authentication)
+2. Visible in OpenAPI documentation
+3. Expose internal network topology
+
+**Solution: Conditional Registration**
+Rather than adding authentication (which would return 401/403 and confirm endpoint existence), we simply don't register the endpoints when disabled. This returns a clean 404 that doesn't leak any information.
+
+### Project Structure Notes
+
+- Config: `backend/app/core/config.py` - Add DEBUG_ENDPOINTS_ENABLED setting
+- API: `backend/app/api/v1/system.py` - Wrap endpoints in conditional
+- Env: `backend/.env.example` - Document new variable
+- Tests: `backend/tests/test_api/test_system.py` - Add security tests
+
+### References
+
+- [Source: docs/sprint-artifacts/tech-spec-epic-P14-1.md#Story-P14-1.2]
+- [Source: docs/epics-phase14.md#Story-P14-1.2]
+- [Source: docs/backlog.md#TD-023]
+
+## Dev Agent Record
+
+### Context Reference
+
+<!-- N/A - YOLO workflow -->
+
+### Agent Model Used
+
+Claude Opus 4.5 (claude-opus-4-5-20251101)
+
+### Debug Log References
+
+- All 3 security tests pass
+
+### Completion Notes List
+
+- Added `DEBUG_ENDPOINTS_ENABLED` setting to config.py with default=False
+- Wrapped debug endpoints in conditional block - endpoints are not registered when disabled
+- Added `include_in_schema=False` to hide from OpenAPI even when enabled
+- Added security warning log when endpoints are enabled
+- Updated .env.example with security warning documentation
+- Added 3 new unit tests for endpoint security
+
+### File List
+
+- MODIFIED: `backend/app/core/config.py` - Added DEBUG_ENDPOINTS_ENABLED setting
+- MODIFIED: `backend/app/api/v1/system.py` - Conditional endpoint registration
+- MODIFIED: `backend/.env.example` - Documented new setting
+- MODIFIED: `backend/tests/test_api/test_system.py` - Added security tests
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2025-12-29 | Story drafted from Epic P14-1 | SM Agent |

--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -843,7 +843,7 @@ development_status:
   # Backlog: TD-011, TD-023
   epic-p14-1: contexted  # Tech spec: docs/sprint-artifacts/tech-spec-epic-P14-1.md
   p14-1-1-fix-asyncio-run-misuse-in-mqtt-service: done
-  p14-1-2-remove-or-secure-debug-endpoints: backlog
+  p14-1-2-remove-or-secure-debug-endpoints: done
   epic-p14-1-retrospective: optional
 
   # Epic P14-2: Backend Code Quality


### PR DESCRIPTION
## Summary

Story P14-1.2: Remove or Secure Debug Endpoints

### Problem
Debug endpoints `/api/v1/system/debug/ai-keys` and `/api/v1/system/debug/network` were always available without authentication, exposing sensitive information:
- **`/debug/ai-keys`**: API key storage structure, encrypted prefixes, key lengths
- **`/debug/network`**: Internal IP addresses (10.0.1.254), RTSP URLs with credentials, network topology

### Solution
Added `DEBUG_ENDPOINTS_ENABLED` configuration setting with these behaviors:

| Setting | Behavior |
|---------|----------|
| `false` (default) | Endpoints return 404 (not registered), not in OpenAPI |
| `true` | Endpoints work, still hidden from OpenAPI, warning logged |

**Why 404 vs 401?** By not registering the endpoints at all when disabled, we return a clean 404 that doesn't confirm the endpoints exist. A 401/403 would reveal that the endpoint exists but is protected.

### Changes

| File | Change |
|------|--------|
| `backend/app/core/config.py` | Added `DEBUG_ENDPOINTS_ENABLED` setting (default: false) |
| `backend/app/api/v1/system.py` | Conditional endpoint registration with `include_in_schema=False` |
| `backend/.env.example` | Documented new setting with security warning |
| `backend/tests/test_api/test_system.py` | Added 3 security tests |
| `docs/sprint-artifacts/P14-1-2.md` | Story documentation |
| `docs/sprint-artifacts/sprint-status.yaml` | Updated story status |

## Test plan

- [x] Test `/debug/ai-keys` returns 404 when disabled (default)
- [x] Test `/debug/network` returns 404 when disabled (default)
- [x] Test debug endpoints not in OpenAPI schema when disabled
- [ ] Manual test: Enable `DEBUG_ENDPOINTS_ENABLED=true` and verify endpoints work

## Security Considerations

- Default is secure (disabled)
- Existing deployments will automatically have debug endpoints disabled after update
- Users who need debug endpoints must explicitly enable them
- Security warning logged when endpoints are enabled

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)