### PR TITLE
feat(P14-5.7): Fix timestamp timezone handling across models

### DIFF
--- a/backend/alembic/versions/059_fix_timestamp_timezone_handling.py
+++ b/backend/alembic/versions/059_fix_timestamp_timezone_handling.py
@@ -1,0 +1,71 @@
+"""fix_timestamp_timezone_handling
+
+Revision ID: 059
+Revises: 058
+Create Date: 2025-12-30 14:00:00.000000
+
+Story P14-5.7: Fix Timestamp Timezone Handling
+
+This migration documents the model changes for consistent UTC timestamp handling.
+
+Changes made to models (in Python code):
+- ActivitySummary: period_start, period_end, generated_at -> DateTime(timezone=True)
+- SystemSetting: updated_at -> default=lambda instead of server_default=func.now()
+- HomeKitConfig: created_at, updated_at -> DateTime(timezone=True)
+- HomeKitAccessory: created_at -> DateTime(timezone=True)
+- User: created_at, last_login -> DateTime(timezone=True)
+
+SQLite Note:
+SQLite stores datetime as TEXT in ISO 8601 format. The timezone=True parameter
+affects Python-side handling and PostgreSQL type selection, but SQLite does not
+require schema changes. This migration is essentially a no-op for SQLite but
+ensures model and schema definitions are synchronized.
+
+PostgreSQL Note:
+For PostgreSQL, this would require ALTER COLUMN ... TYPE TIMESTAMP WITH TIME ZONE.
+Since ArgusAI primarily uses SQLite, we skip actual column alterations.
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '059'
+down_revision = '058'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """
+    Document timezone-aware DateTime column changes.
+
+    This is a no-op migration for SQLite as it stores datetime as TEXT.
+    The actual changes are in the model definitions:
+    - Added timezone=True to DateTime columns
+    - Changed server_default=func.now() to Python default for consistency
+    """
+    # For SQLite: No schema changes needed
+    # The model changes ensure Python handles timezones consistently
+    #
+    # Affected columns (model changes only):
+    # - activity_summaries.period_start: DateTime -> DateTime(timezone=True)
+    # - activity_summaries.period_end: DateTime -> DateTime(timezone=True)
+    # - activity_summaries.generated_at: DateTime -> DateTime(timezone=True)
+    # - system_settings.updated_at: server_default=func.now() -> default=lambda: datetime.now(timezone.utc)
+    # - homekit_config.created_at: DateTime -> DateTime(timezone=True)
+    # - homekit_config.updated_at: DateTime -> DateTime(timezone=True)
+    # - homekit_accessories.created_at: DateTime -> DateTime(timezone=True)
+    # - users.created_at: DateTime -> DateTime(timezone=True)
+    # - users.last_login: DateTime -> DateTime(timezone=True)
+    pass
+
+
+def downgrade() -> None:
+    """
+    Downgrade is a no-op since no schema changes were made.
+
+    Model changes would need to be manually reverted:
+    - Remove timezone=True from DateTime columns
+    - Change default=lambda back to server_default=func.now() for system_settings
+    """
+    pass

--- a/backend/app/models/activity_summary.py
+++ b/backend/app/models/activity_summary.py
@@ -54,17 +54,17 @@ class ActivitySummary(Base):
     )
 
     period_start = Column(
-        DateTime,
+        DateTime(timezone=True),
         nullable=False,
         index=True,
-        doc="Start of summarized time period"
+        doc="Start of summarized time period (UTC)"
     )
 
     period_end = Column(
-        DateTime,
+        DateTime(timezone=True),
         nullable=False,
         index=True,
-        doc="End of summarized time period"
+        doc="End of summarized time period (UTC)"
     )
 
     event_count = Column(
@@ -81,10 +81,10 @@ class ActivitySummary(Base):
     )
 
     generated_at = Column(
-        DateTime,
+        DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
-        doc="When summary was generated"
+        doc="When summary was generated (UTC)"
     )
 
     ai_cost = Column(

--- a/backend/app/models/homekit.py
+++ b/backend/app/models/homekit.py
@@ -44,9 +44,10 @@ class HomeKitConfig(Base):
     port = Column(Integer, default=51826, nullable=False)
     motion_reset_seconds = Column(Integer, default=30, nullable=False)
     max_motion_duration = Column(Integer, default=300, nullable=False)
-    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
+    # Story P14-5.7: Add timezone=True for consistent UTC handling
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
     updated_at = Column(
-        DateTime,
+        DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
         nullable=False
@@ -149,7 +150,8 @@ class HomeKitAccessory(Base):
     accessory_aid = Column(Integer, nullable=True)  # HAP accessory ID, assigned when added to bridge
     accessory_type = Column(String(32), default="motion", nullable=False)  # camera, motion, occupancy, doorbell
     enabled = Column(Boolean, default=True, nullable=False)
-    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
+    # Story P14-5.7: Add timezone=True for consistent UTC handling
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
 
     # Relationships
     config = relationship("HomeKitConfig", back_populates="accessories")

--- a/backend/app/models/system_setting.py
+++ b/backend/app/models/system_setting.py
@@ -1,6 +1,8 @@
 """System settings model for configuration key-value storage"""
+from datetime import datetime, timezone
+
 from sqlalchemy import Column, String, DateTime
-from sqlalchemy.sql import func
+
 from app.core.database import Base
 
 
@@ -18,7 +20,12 @@ class SystemSetting(Base):
 
     key = Column(String(100), primary_key=True, nullable=False)
     value = Column(String(2000), nullable=False)  # JSON or encrypted: prefix for sensitive data
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    # Story P14-5.7: Use Python UTC default instead of server_default for consistent timezone handling
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc)
+    )
 
     def __repr__(self):
         # Don't expose value in repr for security

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -29,8 +29,9 @@ class User(Base):
     username = Column(String(50), unique=True, nullable=False, index=True)
     password_hash = Column(String(60), nullable=False)
     is_active = Column(Boolean, default=True, nullable=False)
-    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
-    last_login = Column(DateTime, nullable=True)
+    # Story P14-5.7: Add timezone=True for consistent UTC handling
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
+    last_login = Column(DateTime(timezone=True), nullable=True)
 
     # Relationship to Device (Story P11-2.4)
     devices = relationship("Device", back_populates="user", cascade="all, delete-orphan")

--- a/docs/sprint-artifacts/P14-5-7-fix-timestamp-timezone-handling.md
+++ b/docs/sprint-artifacts/P14-5-7-fix-timestamp-timezone-handling.md
@@ -1,0 +1,142 @@
+# Story 14-5.7: Fix Timestamp Timezone Handling
+
+Status: done
+
+## Story
+
+As a **developer**,
+I want consistent UTC timestamp handling across all models,
+so that time-based queries work correctly across timezones.
+
+## Acceptance Criteria
+
+1. **AC1**: All DateTime columns have `timezone=True` for timezone-aware storage
+2. **AC2**: `system_setting.py` uses Python UTC default instead of `server_default=func.now()`
+3. **AC3**: `activity_summary.py` DateTime columns (period_start, period_end, generated_at) have `timezone=True`
+4. **AC4**: `homekit.py` DateTime columns (created_at, updated_at) have `timezone=True`
+5. **AC5**: `user.py` DateTime columns (created_at, last_login) have `timezone=True`
+6. **AC6**: Alembic migration updates column definitions for SQLite compatibility
+7. **AC7**: Migration is reversible
+8. **AC8**: Existing data timestamps are preserved (no data corruption)
+
+## Tasks / Subtasks
+
+- [x] Task 1: Audit all DateTime columns in models (AC: #1)
+  - [x] Identify columns missing `timezone=True`
+  - [x] Document current state
+- [x] Task 2: Update ActivitySummary model (AC: #3)
+  - [x] Add `timezone=True` to period_start, period_end, generated_at
+- [x] Task 3: Update SystemSetting model (AC: #2)
+  - [x] Change `server_default=func.now()` to `default=lambda: datetime.now(timezone.utc)`
+  - [x] Keep `onupdate` behavior
+- [x] Task 4: Update HomeKit models (AC: #4)
+  - [x] Add `timezone=True` to HomeKitConfig.created_at, updated_at
+  - [x] Add `timezone=True` to HomeKitAccessory.created_at
+- [x] Task 5: Update User model (AC: #5)
+  - [x] Add `timezone=True` to created_at, last_login
+- [x] Task 6: Create Alembic migration (AC: #6, #7, #8)
+  - [x] Create migration file 059_fix_timestamp_timezone_handling.py
+  - [x] Handle SQLite compatibility (no-op migration)
+  - [x] Ensure data preservation (no schema changes)
+- [x] Task 7: Test migration (AC: #6, #7, #8)
+  - [x] Verify model imports work
+  - [x] Verify migration syntax is valid
+  - [x] All 76 model tests pass
+
+## Dev Notes
+
+### Technical Implementation
+
+**Columns requiring timezone=True:**
+
+| Model | Column | Current State | Fix Required |
+|-------|--------|--------------|--------------|
+| ActivitySummary | period_start | `DateTime` | Add `timezone=True` |
+| ActivitySummary | period_end | `DateTime` | Add `timezone=True` |
+| ActivitySummary | generated_at | `DateTime` | Add `timezone=True` |
+| SystemSetting | updated_at | `server_default=func.now()` | Use Python default |
+| HomeKitConfig | created_at | `DateTime` | Add `timezone=True` |
+| HomeKitConfig | updated_at | `DateTime` | Add `timezone=True` |
+| HomeKitAccessory | created_at | `DateTime` | Add `timezone=True` |
+| User | created_at | `DateTime` | Add `timezone=True` |
+| User | last_login | `DateTime` | Add `timezone=True` |
+
+**Note**: Many other models already have `DateTime(timezone=True)` - see Event, MotionEvent, AlertRule, etc.
+
+### SQLite Considerations
+
+SQLite stores DATETIME as TEXT in ISO 8601 format. The `timezone=True` parameter primarily affects:
+1. Python-side serialization/deserialization
+2. PostgreSQL TIMESTAMP WITH TIME ZONE type selection
+
+For SQLite, the migration won't change the underlying storage but ensures Python handles timezones correctly.
+
+### server_default vs default
+
+- `server_default=func.now()`: Uses database server time (may differ from app timezone)
+- `default=lambda: datetime.now(timezone.utc)`: Consistent UTC from Python
+
+The latter is preferred for consistency and testability.
+
+### Migration Strategy
+
+Since SQLite doesn't have a native timezone-aware datetime type, the migration will:
+1. Not alter column types (unnecessary for SQLite)
+2. Update model definitions for correct Python handling
+3. Be a no-op migration for SQLite (documentation only)
+
+### Project Structure Notes
+
+- Model files: `backend/app/models/`
+- Migration directory: `backend/alembic/versions/`
+- Next migration number: 059
+
+### References
+
+- [Source: docs/epics-phase14.md#story-p14-5-7]
+- [Source: docs/sprint-artifacts/tech-spec-epic-P14-5.md]
+- [Pattern: backend/app/models/event.py - existing DateTime(timezone=True) usage]
+
+### Learnings from Previous Story
+
+**From Story P14-5.6 (Status: done)**
+
+- SQLite batch_alter_table pattern works well for constraint changes
+- Model tests verify imports and relationships correctly
+- No actual column type migration needed for SQLite - just model definition updates
+
+[Source: docs/sprint-artifacts/P14-5-6-add-check-constraints-on-float-columns.md#Dev-Agent-Record]
+
+## Dev Agent Record
+
+### Context Reference
+
+<!-- Path(s) to story context XML will be added here by context workflow -->
+
+### Agent Model Used
+
+Claude Opus 4.5 (claude-opus-4-5-20251101)
+
+### Debug Log References
+
+None - implementation was straightforward.
+
+### Completion Notes List
+
+- Added `timezone=True` to 9 DateTime columns across 4 models
+- Changed SystemSetting from `server_default=func.now()` to Python UTC default
+- Created Alembic migration 059 as documentation-only (SQLite no-op)
+- All 76 model tests pass
+
+### File List
+
+**MODIFIED:**
+- `backend/app/models/activity_summary.py` - Added timezone=True to period_start, period_end, generated_at
+- `backend/app/models/system_setting.py` - Changed to Python UTC default with timezone=True
+- `backend/app/models/homekit.py` - Added timezone=True to HomeKitConfig and HomeKitAccessory timestamps
+- `backend/app/models/user.py` - Added timezone=True to created_at, last_login
+- `docs/sprint-artifacts/sprint-status.yaml` - Updated story status
+
+**NEW:**
+- `backend/alembic/versions/059_fix_timestamp_timezone_handling.py` - Documentation migration
+- `docs/sprint-artifacts/P14-5-7-fix-timestamp-timezone-handling.md` - Story file

--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -908,7 +908,7 @@ development_status:
   p14-5-4-migrate-services-to-backoff-utility: done  # Enhanced with new retry configs
   p14-5-5-fix-backref-vs-back-populates-inconsistency: done
   p14-5-6-add-check-constraints-on-float-columns: done  # GH #322, PR #323
-  p14-5-7-fix-timestamp-timezone-handling: backlog  # Requires Alembic migration
+  p14-5-7-fix-timestamp-timezone-handling: done  # GH #324
   p14-5-8-standardize-api-response-format: backlog  # Documentation task
   p14-5-9-add-notification-model-relationships: done
   p14-5-10-improve-json-parse-error-handling: done


### PR DESCRIPTION
## Summary

Ensure consistent UTC timestamp handling across all SQLAlchemy models.

### Changes

- **ActivitySummary**: Add `timezone=True` to `period_start`, `period_end`, `generated_at`
- **SystemSetting**: Change from `server_default=func.now()` to Python UTC default with `timezone=True`
- **HomeKitConfig/Accessory**: Add `timezone=True` to `created_at`, `updated_at`
- **User**: Add `timezone=True` to `created_at`, `last_login`
- **Migration**: Add Alembic migration 059 (documentation-only for SQLite)

### Technical Details

SQLite stores datetime as TEXT in ISO 8601 format, so the `timezone=True` parameter primarily affects:
1. Python-side serialization/deserialization
2. PostgreSQL TIMESTAMP WITH TIME ZONE type selection

The migration is a no-op for SQLite but ensures model definitions are synchronized with intended behavior.

### Why server_default=func.now() was changed

- `server_default=func.now()`: Uses database server time (may differ from app timezone)
- `default=lambda: datetime.now(timezone.utc)`: Consistent UTC from Python

Closes #324

## Test plan

- [x] Model imports work
- [x] Migration syntax is valid
- [x] All 76 model tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)