### PR TITLE
feat(P15-2): Authentication & User Management

### DIFF
--- a/backend/alembic/versions/g1a2b3c4d5e6_add_multiuser_auth_tables.py
+++ b/backend/alembic/versions/g1a2b3c4d5e6_add_multiuser_auth_tables.py
@@ -1,0 +1,95 @@
+"""Add multi-user auth tables (Story P15-2.1, P15-2.2)
+
+Revision ID: g1a2b3c4d5e6
+Revises: f9c5d7e8a1b2
+Create Date: 2025-12-30 10:00:00.000000
+
+Story P15-2.1: User model and database schema
+- Add email column to users table
+- Add role column (enum: admin, operator, viewer)
+- Add must_change_password column
+- Add password_expires_at column
+- Add updated_at column
+
+Story P15-2.2: Session model and tracking
+- Create sessions table for session tracking
+"""
+from alembic import op
+import sqlalchemy as sa
+from datetime import datetime, timezone
+
+
+# revision identifiers, used by Alembic.
+revision = 'g1a2b3c4d5e6'
+down_revision = 'f9c5d7e8a1b2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create sessions table first (before adding relationships to users)
+    op.create_table(
+        'sessions',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column('user_id', sa.String(36), sa.ForeignKey('users.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('token_hash', sa.String(64), nullable=False, unique=True),
+        sa.Column('device_info', sa.String(255), nullable=True),
+        sa.Column('ip_address', sa.String(45), nullable=True),
+        sa.Column('user_agent', sa.String(512), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc)),
+        sa.Column('last_active_at', sa.DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc)),
+        sa.Column('expires_at', sa.DateTime(timezone=True), nullable=False),
+    )
+
+    # Create indexes for sessions table
+    op.create_index('idx_sessions_user_id', 'sessions', ['user_id'])
+    op.create_index('idx_sessions_token_hash', 'sessions', ['token_hash'])
+    op.create_index('idx_sessions_expires_at', 'sessions', ['expires_at'])
+    op.create_index('idx_sessions_user_expires', 'sessions', ['user_id', 'expires_at'])
+    op.create_index('idx_sessions_user_created', 'sessions', ['user_id', 'created_at'])
+
+    # Add new columns to users table
+    # Note: For SQLite, we need to handle existing NULL values properly
+
+    # Add email column (nullable for backwards compatibility)
+    op.add_column('users', sa.Column('email', sa.String(255), nullable=True, unique=True))
+    op.create_index('idx_users_email', 'users', ['email'])
+
+    # Add role column with default 'admin' for existing users
+    op.add_column('users', sa.Column('role', sa.String(20), nullable=False, server_default='admin'))
+    op.create_index('idx_users_role', 'users', ['role'])
+
+    # Add must_change_password column
+    op.add_column('users', sa.Column('must_change_password', sa.Boolean(), nullable=False, server_default='0'))
+
+    # Add password_expires_at column
+    op.add_column('users', sa.Column('password_expires_at', sa.DateTime(timezone=True), nullable=True))
+
+    # Add updated_at column with current timestamp as default
+    op.add_column('users', sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True))
+
+    # Update existing users to have updated_at = created_at
+    op.execute("UPDATE users SET updated_at = created_at WHERE updated_at IS NULL")
+
+    # Create composite index for common queries
+    op.create_index('idx_users_active_role', 'users', ['is_active', 'role'])
+
+
+def downgrade() -> None:
+    # Drop indexes and columns from users table
+    op.drop_index('idx_users_active_role', table_name='users')
+    op.drop_column('users', 'updated_at')
+    op.drop_column('users', 'password_expires_at')
+    op.drop_column('users', 'must_change_password')
+    op.drop_index('idx_users_role', table_name='users')
+    op.drop_column('users', 'role')
+    op.drop_index('idx_users_email', table_name='users')
+    op.drop_column('users', 'email')
+
+    # Drop sessions table and indexes
+    op.drop_index('idx_sessions_user_created', table_name='sessions')
+    op.drop_index('idx_sessions_user_expires', table_name='sessions')
+    op.drop_index('idx_sessions_expires_at', table_name='sessions')
+    op.drop_index('idx_sessions_token_hash', table_name='sessions')
+    op.drop_index('idx_sessions_user_id', table_name='sessions')
+    op.drop_table('sessions')

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -1,24 +1,30 @@
-"""Authentication API endpoints (Story 6.3)"""
+"""Authentication API endpoints (Story 6.3, P15-2)"""
 from fastapi import APIRouter, Depends, HTTPException, status, Request, Response
 from sqlalchemy.orm import Session
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from datetime import datetime, timezone
+from typing import List
 import secrets
 import logging
 
 from app.core.database import get_db
 from app.core.config import settings
-from app.models.user import User
+from app.models.user import User, UserRole
+from app.models.session import Session as SessionModel
 from app.schemas.auth import (
     LoginRequest,
     LoginResponse,
     UserResponse,
     ChangePasswordRequest,
     MessageResponse,
+    SessionResponse,
+    SessionRevokeResponse,
 )
 from app.utils.auth import hash_password, verify_password, validate_password_strength
 from app.utils.jwt import create_access_token, decode_access_token, TokenError
+from app.services.session_service import SessionService
+from app.services.user_service import UserService
 
 logger = logging.getLogger(__name__)
 
@@ -98,31 +104,18 @@ def ensure_admin_exists(db: Session) -> tuple[bool, str]:
     Returns:
         Tuple of (created, password) - password only returned if newly created
     """
-    existing_users = db.query(User).count()
-    if existing_users > 0:
-        return False, ""
+    user_service = UserService(db)
+    return user_service.ensure_admin_exists()
 
-    # Generate secure random password
-    password = secrets.token_urlsafe(16)
 
-    admin = User(
-        username="admin",
-        password_hash=hash_password(password),
-        is_active=True,
-    )
-
-    db.add(admin)
-    db.commit()
-
-    logger.info(
-        "Created default admin user",
-        extra={
-            "event_type": "admin_user_created",
-            "username": "admin"
-        }
-    )
-
-    return True, password
+def get_current_token(request: Request) -> str | None:
+    """Extract current JWT token from request"""
+    token = request.cookies.get(COOKIE_NAME)
+    if not token:
+        auth_header = request.headers.get("Authorization")
+        if auth_header and auth_header.startswith("Bearer "):
+            token = auth_header[7:]
+    return token
 
 
 @router.post(
@@ -144,10 +137,13 @@ async def login(
     db: Session = Depends(get_db),
 ):
     """
-    Login with username and password
+    Login with username and password (Story P15-2.6)
 
     Returns JWT token in response body and sets HTTP-only cookie.
     Rate limited to 5 attempts per 15 minutes per IP.
+
+    If must_change_password is true, user should be redirected to
+    password change screen before accessing other pages.
     """
     # Find user
     user = db.query(User).filter(User.username == credentials.username.lower()).first()
@@ -198,12 +194,31 @@ async def login(
             detail="Account disabled",
         )
 
+    # Check if temporary password has expired (Story P15-2.5)
+    if user.password_is_expired():
+        logger.warning(
+            "Login failed - temporary password expired",
+            extra={
+                "event_type": "login_failed",
+                "reason": "password_expired",
+                "username": credentials.username,
+            }
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Temporary password has expired. Please contact an administrator.",
+        )
+
     # Update last login
     user.last_login = datetime.now(timezone.utc)
     db.commit()
 
     # Create JWT token
     access_token = create_access_token(user.id, user.username)
+
+    # Create server-side session (Story P15-2.7)
+    session_service = SessionService(db)
+    session_service.create_session(user, access_token, request)
 
     # Set HTTP-only cookie
     # Cookie settings configurable via COOKIE_SECURE and COOKIE_SAMESITE env vars
@@ -226,13 +241,24 @@ async def login(
             "user_id": user.id,
             "username": user.username,
             "ip_address": get_remote_address(request),
+            "must_change_password": user.must_change_password,
         }
     )
 
     return LoginResponse(
         access_token=access_token,
         token_type="bearer",
-        user=UserResponse.model_validate(user),
+        user=UserResponse(
+            id=user.id,
+            username=user.username,
+            email=user.email,
+            role=user.role.value if hasattr(user.role, 'value') else str(user.role),
+            is_active=user.is_active,
+            must_change_password=user.must_change_password,
+            created_at=user.created_at,
+            last_login=user.last_login,
+        ),
+        must_change_password=user.must_change_password,
     )
 
 
@@ -240,13 +266,21 @@ async def login(
     "/logout",
     response_model=MessageResponse,
     summary="End user session",
-    description="Logout by clearing the JWT cookie. Does not invalidate the token server-side.",
+    description="Logout by clearing the JWT cookie and invalidating server-side session.",
     response_description="Logout confirmation message",
 )
-async def logout(response: Response):
+async def logout(request: Request, response: Response, db: Session = Depends(get_db)):
     """
-    Logout by clearing JWT cookie
+    Logout by clearing JWT cookie and invalidating server-side session (Story P15-2.7)
     """
+    # Invalidate server-side session
+    token = get_current_token(request)
+    if token:
+        session_service = SessionService(db)
+        session = session_service.get_session_by_token(token)
+        if session:
+            session_service.revoke_session(session.id, session.user_id)
+
     response.delete_cookie(
         key=COOKIE_NAME,
         httponly=True,
@@ -267,11 +301,11 @@ async def logout(response: Response):
     "/change-password",
     response_model=MessageResponse,
     summary="Change user password",
-    description="Change password for current authenticated user. Requires current password verification. New password must be at least 8 characters with 1 uppercase, 1 number, and 1 special character.",
+    description="Change password for current authenticated user. For regular changes, requires current password verification. For forced password changes (must_change_password=true), current password is optional. New password must be at least 8 characters with 1 uppercase, 1 lowercase, 1 number, and 1 special character.",
     response_description="Password change confirmation",
     responses={
-        400: {"description": "New password doesn't meet requirements"},
-        401: {"description": "Current password is incorrect or not authenticated"},
+        400: {"description": "New password doesn't meet requirements or current password is incorrect"},
+        401: {"description": "Not authenticated"},
     },
 )
 async def change_password(
@@ -281,12 +315,18 @@ async def change_password(
     db: Session = Depends(get_db),
 ):
     """
-    Change password for current user
+    Change password for current user (Story P15-2.6)
 
-    Requires current password verification.
+    For forced password changes (must_change_password=true):
+    - Current password verification is optional (can skip)
+
+    For regular password changes:
+    - Requires current password verification
+
     New password must meet security requirements:
     - At least 8 characters
     - At least 1 uppercase letter
+    - At least 1 lowercase letter
     - At least 1 number
     - At least 1 special character
     """
@@ -298,20 +338,29 @@ async def change_password(
             detail="User not found",
         )
 
-    # Verify current password
-    if not verify_password(password_data.current_password, user.password_hash):
-        logger.warning(
-            "Password change failed - incorrect current password",
-            extra={
-                "event_type": "password_change_failed",
-                "reason": "incorrect_password",
-                "user_id": user.id,
-            }
-        )
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Current password is incorrect",
-        )
+    # For forced password changes, current password verification is optional
+    # For regular changes, require current password
+    if not user.must_change_password:
+        # Regular change - require current password
+        if not password_data.current_password:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Current password is required",
+            )
+
+        if not verify_password(password_data.current_password, user.password_hash):
+            logger.warning(
+                "Password change failed - incorrect current password",
+                extra={
+                    "event_type": "password_change_failed",
+                    "reason": "incorrect_password",
+                    "user_id": user.id,
+                }
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Current password is incorrect",
+            )
 
     # Validate new password strength
     is_valid, error_message = validate_password_strength(password_data.new_password)
@@ -321,33 +370,20 @@ async def change_password(
             detail=error_message,
         )
 
-    # Update password
-    new_hash = hash_password(password_data.new_password)
-    user.password_hash = new_hash
-    db.add(user)  # Explicitly add to session to ensure change is tracked
-    db.commit()
-    db.refresh(user)  # Refresh to confirm change was persisted
-
-    # Verify the change was saved
-    if user.password_hash != new_hash:
-        logger.error(
-            "Password change failed - hash not persisted",
-            extra={
-                "event_type": "password_change_failed",
-                "reason": "persistence_error",
-                "user_id": user.id,
-            }
-        )
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to save password change",
-        )
+    # Update password using UserService
+    user_service = UserService(db)
+    user_service.change_password(
+        user=user,
+        new_password=password_data.new_password,
+        clear_must_change=True  # Always clear the flag after successful change
+    )
 
     logger.info(
         "Password changed successfully",
         extra={
             "event_type": "password_changed",
             "user_id": user.id,
+            "was_forced": current_user.must_change_password,
         }
     )
 
@@ -385,3 +421,110 @@ async def get_setup_status(db: Session = Depends(get_db)):
         "setup_complete": user_count > 0,
         "user_count": user_count,
     }
+
+
+# Session Management Endpoints (Story P15-2.7)
+
+@router.get(
+    "/sessions",
+    response_model=List[SessionResponse],
+    summary="List active sessions",
+    description="Get list of all active sessions for the current user. Current session is marked with is_current=true.",
+    responses={
+        401: {"description": "Not authenticated"},
+    },
+)
+async def list_sessions(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    List all active sessions for current user (Story P15-2.7)
+
+    Returns sessions with device info, IP address, and timestamps.
+    Current session is marked with is_current=true.
+    """
+    session_service = SessionService(db)
+    token = get_current_token(request)
+    sessions = session_service.get_user_sessions(current_user.id, token)
+
+    return [SessionResponse(**session) for session in sessions]
+
+
+@router.delete(
+    "/sessions/{session_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Revoke specific session",
+    description="Revoke a specific session by ID. Cannot revoke the current session.",
+    responses={
+        400: {"description": "Cannot revoke current session"},
+        401: {"description": "Not authenticated"},
+        404: {"description": "Session not found"},
+    },
+)
+async def revoke_session(
+    session_id: str,
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Revoke a specific session (Story P15-2.7)
+
+    Cannot revoke the current session - use logout instead.
+    """
+    session_service = SessionService(db)
+
+    # Check if trying to revoke current session
+    token = get_current_token(request)
+    if token:
+        current_session = session_service.get_session_by_token(token)
+        if current_session and current_session.id == session_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Cannot revoke current session. Use logout instead.",
+            )
+
+    if not session_service.revoke_session(session_id, current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Session not found",
+        )
+
+    return None
+
+
+@router.delete(
+    "/sessions",
+    response_model=SessionRevokeResponse,
+    summary="Revoke all other sessions",
+    description="Revoke all sessions except the current one.",
+    responses={
+        401: {"description": "Not authenticated"},
+    },
+)
+async def revoke_all_sessions(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Revoke all sessions except current (Story P15-2.7)
+    """
+    session_service = SessionService(db)
+
+    # Get current session ID to exclude
+    token = get_current_token(request)
+    current_session_id = None
+    if token:
+        current_session = session_service.get_session_by_token(token)
+        if current_session:
+            current_session_id = current_session.id
+
+    count = session_service.revoke_all_sessions(
+        current_user.id,
+        except_session_id=current_session_id
+    )
+
+    return SessionRevokeResponse(revoked_count=count)

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -1,0 +1,264 @@
+"""User management API endpoints (Story P15-2.3)
+
+Admin-only endpoints for managing user accounts.
+
+Permission Matrix:
+- All endpoints require admin role
+- Regular users can only manage their own profile via /auth endpoints
+"""
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from typing import List
+import logging
+
+from app.core.database import get_db
+from app.core.permissions import require_role
+from app.models.user import User, UserRole
+from app.schemas.auth import (
+    UserResponse,
+    UserCreate,
+    UserCreateResponse,
+    UserUpdate,
+    PasswordResetResponse,
+)
+from app.services.user_service import UserService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/users", tags=["User Management"])
+
+
+@router.post(
+    "",
+    response_model=UserCreateResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create new user",
+    description="Create a new user account with temporary password. Admin only. "
+                "Returns temporary password that must be changed on first login.",
+    responses={
+        400: {"description": "Username or email already exists"},
+        403: {"description": "Not authorized - admin role required"},
+    },
+)
+async def create_user(
+    user_data: UserCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.ADMIN)),
+):
+    """
+    Create a new user account (Admin only)
+
+    - Generates secure temporary password
+    - Sets must_change_password flag
+    - Password expires in 72 hours if not changed
+    """
+    service = UserService(db)
+
+    try:
+        user, temp_password = service.create_user(
+            username=user_data.username,
+            role=user_data.role,
+            email=user_data.email,
+            send_email=user_data.send_email,
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
+
+    return UserCreateResponse(
+        id=user.id,
+        username=user.username,
+        email=user.email,
+        role=user.role.value if hasattr(user.role, 'value') else str(user.role),
+        temporary_password=temp_password if not user_data.send_email else None,
+        password_expires_at=user.password_expires_at,
+        created_at=user.created_at,
+    )
+
+
+@router.get(
+    "",
+    response_model=List[UserResponse],
+    summary="List all users",
+    description="Get list of all user accounts. Admin only.",
+    responses={
+        403: {"description": "Not authorized - admin role required"},
+    },
+)
+async def list_users(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.ADMIN)),
+):
+    """List all users (Admin only)"""
+    service = UserService(db)
+    users = service.list_users()
+
+    return [
+        UserResponse(
+            id=user.id,
+            username=user.username,
+            email=user.email,
+            role=user.role.value if hasattr(user.role, 'value') else str(user.role),
+            is_active=user.is_active,
+            must_change_password=user.must_change_password,
+            created_at=user.created_at,
+            last_login=user.last_login,
+        )
+        for user in users
+    ]
+
+
+@router.get(
+    "/{user_id}",
+    response_model=UserResponse,
+    summary="Get user details",
+    description="Get details for a specific user. Admin only.",
+    responses={
+        403: {"description": "Not authorized - admin role required"},
+        404: {"description": "User not found"},
+    },
+)
+async def get_user(
+    user_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.ADMIN)),
+):
+    """Get user by ID (Admin only)"""
+    service = UserService(db)
+    user = service.get_user(user_id)
+
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found"
+        )
+
+    return UserResponse(
+        id=user.id,
+        username=user.username,
+        email=user.email,
+        role=user.role.value if hasattr(user.role, 'value') else str(user.role),
+        is_active=user.is_active,
+        must_change_password=user.must_change_password,
+        created_at=user.created_at,
+        last_login=user.last_login,
+    )
+
+
+@router.put(
+    "/{user_id}",
+    response_model=UserResponse,
+    summary="Update user",
+    description="Update user details. Admin only. Cannot update username.",
+    responses={
+        400: {"description": "Invalid data or email already exists"},
+        403: {"description": "Not authorized - admin role required"},
+        404: {"description": "User not found"},
+    },
+)
+async def update_user(
+    user_id: str,
+    user_data: UserUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.ADMIN)),
+):
+    """Update user details (Admin only)"""
+    service = UserService(db)
+
+    try:
+        user = service.update_user(
+            user_id=user_id,
+            email=user_data.email,
+            role=user_data.role,
+            is_active=user_data.is_active,
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
+
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found"
+        )
+
+    return UserResponse(
+        id=user.id,
+        username=user.username,
+        email=user.email,
+        role=user.role.value if hasattr(user.role, 'value') else str(user.role),
+        is_active=user.is_active,
+        must_change_password=user.must_change_password,
+        created_at=user.created_at,
+        last_login=user.last_login,
+    )
+
+
+@router.delete(
+    "/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete user",
+    description="Delete a user account. Admin only. Cannot delete yourself.",
+    responses={
+        400: {"description": "Cannot delete yourself"},
+        403: {"description": "Not authorized - admin role required"},
+        404: {"description": "User not found"},
+    },
+)
+async def delete_user(
+    user_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.ADMIN)),
+):
+    """Delete user (Admin only)"""
+    # Prevent self-deletion
+    if user_id == current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot delete your own account"
+        )
+
+    service = UserService(db)
+    if not service.delete_user(user_id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found"
+        )
+
+    return None
+
+
+@router.post(
+    "/{user_id}/reset",
+    response_model=PasswordResetResponse,
+    summary="Reset user password",
+    description="Reset user password to a new temporary password. Admin only. "
+                "Invalidates all existing sessions.",
+    responses={
+        403: {"description": "Not authorized - admin role required"},
+        404: {"description": "User not found"},
+    },
+)
+async def reset_password(
+    user_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.ADMIN)),
+):
+    """Reset user password (Admin only)"""
+    service = UserService(db)
+    temp_password, expires_at = service.reset_password(user_id)
+
+    if not temp_password:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found"
+        )
+
+    return PasswordResetResponse(
+        temporary_password=temp_password,
+        expires_at=expires_at,
+    )

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -1,0 +1,142 @@
+"""Role-based access control permissions (Story P15-2.9)
+
+Provides FastAPI dependencies for enforcing role-based permissions on API endpoints.
+
+ADR-P15-003: Three-role RBAC (admin, operator, viewer)
+- Admin: Full system access including user management
+- Operator: Manage events, entities, cameras but not users
+- Viewer: Read-only access to dashboard and events
+
+Permission Matrix:
+| Endpoint Pattern          | Admin | Operator | Viewer |
+|---------------------------|-------|----------|--------|
+| GET /events/*             | Yes   | Yes      | Yes    |
+| POST/PUT/DELETE /events/* | Yes   | Yes      | No     |
+| */users/*                 | Yes   | No       | No     |
+| PUT /system/*             | Yes   | No       | No     |
+| GET /cameras/*            | Yes   | Yes      | Yes    |
+| POST/PUT/DELETE /cameras/*| Yes   | Yes      | No     |
+| GET /entities/*           | Yes   | Yes      | Yes    |
+| POST/PUT/DELETE /entities/*| Yes  | Yes      | No     |
+"""
+from functools import wraps
+from typing import List, Callable
+from fastapi import HTTPException, status, Depends, Request
+from sqlalchemy.orm import Session
+import logging
+
+from app.core.database import get_db
+from app.models.user import User, UserRole
+
+logger = logging.getLogger(__name__)
+
+
+class PermissionDenied(HTTPException):
+    """Exception raised when user lacks required permissions"""
+
+    def __init__(self, detail: str = "Not authorized for this action"):
+        super().__init__(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=detail
+        )
+
+
+def require_role(*allowed_roles: UserRole):
+    """
+    Dependency factory that checks if user has one of the allowed roles.
+
+    Usage:
+        @router.get("/users")
+        async def list_users(user: User = Depends(require_role(UserRole.ADMIN))):
+            ...
+
+        @router.post("/events")
+        async def create_event(user: User = Depends(require_role(UserRole.ADMIN, UserRole.OPERATOR))):
+            ...
+
+    Args:
+        *allowed_roles: One or more UserRole values that are permitted
+
+    Returns:
+        A dependency function that validates the user's role
+    """
+    from app.api.v1.auth import get_current_user  # Import here to avoid circular import
+
+    async def check_role(
+        request: Request,
+        db: Session = Depends(get_db)
+    ) -> User:
+        # Get current user using existing auth mechanism
+        current_user = get_current_user(request, db)
+
+        # Check if user's role is in allowed roles
+        if current_user.role not in allowed_roles:
+            logger.warning(
+                "Permission denied",
+                extra={
+                    "event_type": "permission_denied",
+                    "user_id": current_user.id,
+                    "username": current_user.username,
+                    "user_role": current_user.role.value if hasattr(current_user.role, 'value') else str(current_user.role),
+                    "required_roles": [r.value for r in allowed_roles],
+                    "path": request.url.path,
+                    "method": request.method,
+                }
+            )
+            raise PermissionDenied(
+                detail=f"Role '{current_user.role.value if hasattr(current_user.role, 'value') else current_user.role}' "
+                       f"is not authorized for this action"
+            )
+
+        return current_user
+
+    return check_role
+
+
+def require_admin():
+    """Shorthand for require_role(UserRole.ADMIN)"""
+    return require_role(UserRole.ADMIN)
+
+
+def require_operator_or_admin():
+    """Shorthand for require_role(UserRole.ADMIN, UserRole.OPERATOR)"""
+    return require_role(UserRole.ADMIN, UserRole.OPERATOR)
+
+
+def require_authenticated():
+    """
+    Dependency that just requires any authenticated user.
+    All roles (admin, operator, viewer) are allowed.
+    """
+    return require_role(UserRole.ADMIN, UserRole.OPERATOR, UserRole.VIEWER)
+
+
+# Role checking utilities for use in business logic
+def check_can_manage_users(user: User) -> bool:
+    """Check if user can manage other users (admin only)"""
+    return user.role == UserRole.ADMIN
+
+
+def check_can_manage_events(user: User) -> bool:
+    """Check if user can create/edit/delete events (admin, operator)"""
+    return user.role in (UserRole.ADMIN, UserRole.OPERATOR)
+
+
+def check_can_manage_cameras(user: User) -> bool:
+    """Check if user can create/edit/delete cameras (admin, operator)"""
+    return user.role in (UserRole.ADMIN, UserRole.OPERATOR)
+
+
+def check_can_manage_entities(user: User) -> bool:
+    """Check if user can create/edit/delete entities (admin, operator)"""
+    return user.role in (UserRole.ADMIN, UserRole.OPERATOR)
+
+
+def check_can_manage_settings(user: User) -> bool:
+    """Check if user can modify system settings (admin only)"""
+    return user.role == UserRole.ADMIN
+
+
+def check_can_view(user: User) -> bool:
+    """Check if user can view data (all authenticated users)"""
+    return user.role in (UserRole.ADMIN, UserRole.OPERATOR, UserRole.VIEWER)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -8,7 +8,8 @@ from app.models.event import Event
 from app.models.event_frame import EventFrame
 from app.models.alert_rule import AlertRule, WebhookLog
 from app.models.notification import Notification
-from app.models.user import User
+from app.models.user import User, UserRole
+from app.models.session import Session
 from app.models.system_notification import SystemNotification
 from app.models.push_subscription import PushSubscription
 from app.models.notification_preference import NotificationPreference
@@ -42,6 +43,8 @@ __all__ = [
     "WebhookLog",
     "Notification",
     "User",
+    "UserRole",
+    "Session",
     "SystemNotification",
     "PushSubscription",
     "NotificationPreference",

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -1,0 +1,88 @@
+"""Session SQLAlchemy ORM model for session tracking (Story P15-2.2)"""
+from sqlalchemy import Column, String, Boolean, DateTime, ForeignKey, Index
+from sqlalchemy.orm import relationship
+from app.core.database import Base
+import uuid
+from datetime import datetime, timezone
+import hashlib
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Session(Base):
+    """
+    Session model for tracking active user sessions (Story P15-2.2)
+
+    Tracks all active user sessions with metadata for security monitoring
+    and session management. Each session corresponds to a JWT token.
+
+    Attributes:
+        id: UUID primary key
+        user_id: Foreign key to users table
+        token_hash: SHA-256 hash of JWT token for validation
+        device_info: Parsed device description from User-Agent
+        ip_address: Client IP address
+        user_agent: Full User-Agent string
+        created_at: Session creation timestamp (login time)
+        last_active_at: Last request timestamp (for expiry calculation)
+        expires_at: Session expiration timestamp
+
+    ADR-P15-001: Session-based auth with JWT
+    - HTTP-only cookies prevent XSS
+    - Server-side tracking enables session management
+    - Token hash stored (not token itself) for security
+    """
+
+    __tablename__ = "sessions"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    token_hash = Column(String(64), nullable=False, unique=True, index=True)  # SHA-256 hash
+    device_info = Column(String(255), nullable=True)  # Parsed from User-Agent
+    ip_address = Column(String(45), nullable=True)  # IPv6 can be 45 chars
+    user_agent = Column(String(512), nullable=True)  # Full User-Agent
+    created_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False
+    )
+    last_active_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False
+    )
+    expires_at = Column(DateTime(timezone=True), nullable=False, index=True)
+
+    # Relationship to User
+    user = relationship("User", back_populates="sessions")
+
+    # Composite indexes for common queries
+    __table_args__ = (
+        Index('idx_sessions_user_expires', 'user_id', 'expires_at'),
+        Index('idx_sessions_user_created', 'user_id', 'created_at'),
+    )
+
+    @classmethod
+    def hash_token(cls, token: str) -> str:
+        """
+        Create SHA-256 hash of JWT token
+
+        Args:
+            token: JWT token string
+
+        Returns:
+            Hex-encoded SHA-256 hash (64 characters)
+        """
+        return hashlib.sha256(token.encode('utf-8')).hexdigest()
+
+    def is_expired(self) -> bool:
+        """Check if session has expired"""
+        return datetime.now(timezone.utc) > self.expires_at
+
+    def update_activity(self) -> None:
+        """Update last_active_at to current time"""
+        self.last_active_at = datetime.now(timezone.utc)
+
+    def __repr__(self):
+        return f"<Session(id={self.id}, user_id={self.user_id}, device={self.device_info})>"

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,40 +1,79 @@
-"""User SQLAlchemy ORM model for authentication"""
-from sqlalchemy import Column, String, Boolean, DateTime
+"""User SQLAlchemy ORM model for authentication (Story P15-2.1)"""
+from sqlalchemy import Column, String, Boolean, DateTime, Enum as SQLEnum, Index
 from sqlalchemy.orm import validates, relationship
 from app.core.database import Base
 import uuid
 from datetime import datetime, timezone
+from enum import Enum
 import re
 import logging
 
 logger = logging.getLogger(__name__)
 
 
+class UserRole(str, Enum):
+    """User role enumeration for RBAC (Story P15-2.9)"""
+    ADMIN = "admin"
+    OPERATOR = "operator"
+    VIEWER = "viewer"
+
+
 class User(Base):
     """
-    User model for authentication
+    User model for multi-user authentication (Story P15-2.1)
 
     Attributes:
         id: UUID primary key
         username: Unique login username (3-50 chars, alphanumeric + underscore)
-        password_hash: bcrypt hash (60 chars)
+        email: Unique email address for login (optional, for future email invites)
+        password_hash: bcrypt hash (cost factor 12)
+        role: User role for RBAC (admin, operator, viewer)
         is_active: Whether account is enabled
+        must_change_password: Force password change on next login
+        password_expires_at: Expiry for temporary passwords (72h for invitations)
         created_at: Record creation timestamp (UTC)
+        updated_at: Last modification timestamp (UTC)
         last_login: Last successful login timestamp (UTC)
+
+    ADR-P15-002: Uses bcrypt with cost factor 12 (~250ms hash time)
+    ADR-P15-003: Three-role RBAC (admin, operator, viewer)
     """
 
     __tablename__ = "users"
 
     id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     username = Column(String(50), unique=True, nullable=False, index=True)
+    email = Column(String(255), unique=True, nullable=True, index=True)  # Optional, for future email invites
     password_hash = Column(String(60), nullable=False)
+    role = Column(
+        SQLEnum(UserRole, values_callable=lambda x: [e.value for e in x]),
+        nullable=False,
+        default=UserRole.VIEWER,
+        index=True
+    )
     is_active = Column(Boolean, default=True, nullable=False)
+    must_change_password = Column(Boolean, default=False, nullable=False)
+    password_expires_at = Column(DateTime(timezone=True), nullable=True)  # For temporary passwords
     # Story P14-5.7: Add timezone=True for consistent UTC handling
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False
+    )
     last_login = Column(DateTime(timezone=True), nullable=True)
 
     # Relationship to Device (Story P11-2.4)
     devices = relationship("Device", back_populates="user", cascade="all, delete-orphan")
+
+    # Relationship to Session (Story P15-2.2)
+    sessions = relationship("Session", back_populates="user", cascade="all, delete-orphan")
+
+    # Composite indexes for common queries
+    __table_args__ = (
+        Index('idx_users_active_role', 'is_active', 'role'),
+    )
 
     @validates('username')
     def validate_username(self, key, value):
@@ -56,5 +95,50 @@ class User(Base):
 
         return value.lower()  # Normalize to lowercase
 
+    @validates('email')
+    def validate_email(self, key, value):
+        """Validate email format if provided"""
+        if value is None:
+            return value
+
+        value = value.strip().lower()
+        if not value:
+            return None
+
+        # Basic email validation
+        if not re.match(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$', value):
+            raise ValueError("Invalid email format")
+
+        if len(value) > 255:
+            raise ValueError("Email must be 255 characters or less")
+
+        return value
+
+    def is_admin(self) -> bool:
+        """Check if user has admin role"""
+        return self.role == UserRole.ADMIN
+
+    def is_operator(self) -> bool:
+        """Check if user has operator role"""
+        return self.role == UserRole.OPERATOR
+
+    def is_viewer(self) -> bool:
+        """Check if user has viewer role"""
+        return self.role == UserRole.VIEWER
+
+    def can_manage_users(self) -> bool:
+        """Check if user can manage other users (admin only)"""
+        return self.is_admin()
+
+    def can_manage_events(self) -> bool:
+        """Check if user can manage events (admin, operator)"""
+        return self.role in (UserRole.ADMIN, UserRole.OPERATOR)
+
+    def password_is_expired(self) -> bool:
+        """Check if temporary password has expired"""
+        if self.password_expires_at is None:
+            return False
+        return datetime.now(timezone.utc) > self.password_expires_at
+
     def __repr__(self):
-        return f"<User(id={self.id}, username={self.username}, active={self.is_active})>"
+        return f"<User(id={self.id}, username={self.username}, role={self.role.value}, active={self.is_active})>"

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,7 +1,7 @@
-"""Authentication Pydantic schemas for request/response validation"""
-from pydantic import BaseModel, Field
+"""Authentication Pydantic schemas for request/response validation (Story P15-2)"""
+from pydantic import BaseModel, Field, EmailStr
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Literal
 
 
 class LoginRequest(BaseModel):
@@ -15,13 +15,17 @@ class LoginResponse(BaseModel):
     access_token: str = Field(..., description="JWT access token")
     token_type: str = Field(default="bearer", description="Token type")
     user: "UserResponse" = Field(..., description="User information")
+    must_change_password: bool = Field(default=False, description="Requires password change")
 
 
 class UserResponse(BaseModel):
-    """User information response"""
+    """User information response (Story P15-2.1)"""
     id: str = Field(..., description="User UUID")
     username: str = Field(..., description="Username")
+    email: Optional[str] = Field(None, description="Email address")
+    role: str = Field(..., description="User role (admin, operator, viewer)")
     is_active: bool = Field(..., description="Account active status")
+    must_change_password: bool = Field(default=False, description="Force password change on next login")
     created_at: datetime = Field(..., description="Account creation timestamp")
     last_login: Optional[datetime] = Field(None, description="Last login timestamp")
 
@@ -31,13 +35,68 @@ class UserResponse(BaseModel):
 
 class ChangePasswordRequest(BaseModel):
     """Change password request body"""
-    current_password: str = Field(..., min_length=1, description="Current password")
+    current_password: Optional[str] = Field(None, min_length=1, description="Current password (optional for forced change)")
     new_password: str = Field(..., min_length=8, description="New password (8+ chars, uppercase, number, special)")
 
 
 class MessageResponse(BaseModel):
     """Simple message response"""
     message: str = Field(..., description="Response message")
+
+
+# User Management Schemas (Story P15-2.3)
+class UserCreate(BaseModel):
+    """Create user request (admin only)"""
+    username: str = Field(..., min_length=3, max_length=50, description="Username")
+    email: Optional[EmailStr] = Field(None, description="Email address for notifications")
+    role: Literal["admin", "operator", "viewer"] = Field(default="viewer", description="User role")
+    send_email: bool = Field(default=False, description="Send invitation email")
+
+
+class UserCreateResponse(BaseModel):
+    """Create user response with temporary password"""
+    id: str = Field(..., description="User UUID")
+    username: str = Field(..., description="Username")
+    email: Optional[str] = Field(None, description="Email address")
+    role: str = Field(..., description="User role")
+    temporary_password: Optional[str] = Field(None, description="Temporary password (if not sent via email)")
+    password_expires_at: Optional[datetime] = Field(None, description="Temporary password expiration")
+    created_at: datetime = Field(..., description="Account creation timestamp")
+
+    class Config:
+        from_attributes = True
+
+
+class UserUpdate(BaseModel):
+    """Update user request (admin only)"""
+    email: Optional[EmailStr] = Field(None, description="Email address")
+    role: Optional[Literal["admin", "operator", "viewer"]] = Field(None, description="User role")
+    is_active: Optional[bool] = Field(None, description="Account active status")
+
+
+class PasswordResetResponse(BaseModel):
+    """Password reset response"""
+    temporary_password: str = Field(..., description="New temporary password")
+    expires_at: datetime = Field(..., description="Temporary password expiration")
+
+
+# Session Management Schemas (Story P15-2.7)
+class SessionResponse(BaseModel):
+    """Session information response"""
+    id: str = Field(..., description="Session UUID")
+    device_info: Optional[str] = Field(None, description="Device description")
+    ip_address: Optional[str] = Field(None, description="Client IP address")
+    created_at: datetime = Field(..., description="Session creation timestamp")
+    last_active_at: datetime = Field(..., description="Last activity timestamp")
+    is_current: bool = Field(default=False, description="Is this the current session")
+
+    class Config:
+        from_attributes = True
+
+
+class SessionRevokeResponse(BaseModel):
+    """Response when revoking multiple sessions"""
+    revoked_count: int = Field(..., description="Number of sessions revoked")
 
 
 # Forward reference resolution

--- a/backend/app/services/session_service.py
+++ b/backend/app/services/session_service.py
@@ -1,0 +1,346 @@
+"""Session management service (Story P15-2.7, P15-2.8)
+
+Provides session creation, tracking, expiration, and cleanup functionality.
+
+ADR-P15-001: Session-based auth with JWT
+- HTTP-only cookies prevent XSS
+- Server-side tracking enables session management
+- Token hash stored (not token itself) for security
+"""
+from datetime import datetime, timezone, timedelta
+from typing import Optional, List
+from sqlalchemy.orm import Session as DBSession
+from sqlalchemy import desc
+from fastapi import Request
+import logging
+import re
+
+from app.models.session import Session
+from app.models.user import User
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Default settings - can be overridden in config
+DEFAULT_SESSION_EXPIRY_HOURS = 24
+DEFAULT_MAX_SESSIONS_PER_USER = 5
+
+
+class SessionService:
+    """
+    Service for managing user sessions (Story P15-2.7, P15-2.8)
+
+    Responsibilities:
+    - Create new sessions with device/IP tracking
+    - Enforce session limits per user
+    - Track session activity
+    - Revoke sessions
+    - Clean up expired sessions
+    """
+
+    def __init__(self, db: DBSession):
+        self.db = db
+        self.session_expiry_hours = getattr(settings, 'SESSION_EXPIRY_HOURS', DEFAULT_SESSION_EXPIRY_HOURS)
+        self.max_sessions = getattr(settings, 'MAX_SESSIONS_PER_USER', DEFAULT_MAX_SESSIONS_PER_USER)
+
+    def create_session(
+        self,
+        user: User,
+        token: str,
+        request: Request
+    ) -> Session:
+        """
+        Create a new session for a user.
+
+        Enforces max sessions limit - if user has max sessions,
+        the oldest one is deleted.
+
+        Args:
+            user: User to create session for
+            token: JWT token for this session
+            request: FastAPI request for extracting device info
+
+        Returns:
+            Created Session object
+        """
+        # Check and enforce session limit
+        user_sessions = self._get_user_sessions(user.id)
+        if len(user_sessions) >= self.max_sessions:
+            # Delete oldest session(s) to make room
+            sessions_to_delete = len(user_sessions) - self.max_sessions + 1
+            for session in user_sessions[:sessions_to_delete]:
+                logger.info(
+                    "Deleting oldest session due to limit",
+                    extra={
+                        "event_type": "session_limit_enforced",
+                        "user_id": user.id,
+                        "deleted_session_id": session.id,
+                    }
+                )
+                self.db.delete(session)
+
+        # Extract device info from request
+        device_info = self._parse_device_info(request)
+        ip_address = self._get_client_ip(request)
+        user_agent = request.headers.get("User-Agent", "")[:512]
+
+        # Calculate expiry
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=self.session_expiry_hours)
+
+        # Create session
+        session = Session(
+            user_id=user.id,
+            token_hash=Session.hash_token(token),
+            device_info=device_info,
+            ip_address=ip_address,
+            user_agent=user_agent,
+            expires_at=expires_at,
+        )
+
+        self.db.add(session)
+        self.db.commit()
+        self.db.refresh(session)
+
+        logger.info(
+            "Session created",
+            extra={
+                "event_type": "session_created",
+                "user_id": user.id,
+                "session_id": session.id,
+                "device_info": device_info,
+                "ip_address": ip_address,
+            }
+        )
+
+        return session
+
+    def get_session_by_token(self, token: str) -> Optional[Session]:
+        """
+        Get session by JWT token.
+
+        Args:
+            token: JWT token
+
+        Returns:
+            Session if found and not expired, None otherwise
+        """
+        token_hash = Session.hash_token(token)
+        session = self.db.query(Session).filter(
+            Session.token_hash == token_hash
+        ).first()
+
+        if session and session.is_expired():
+            # Auto-delete expired session
+            self.db.delete(session)
+            self.db.commit()
+            return None
+
+        return session
+
+    def update_session_activity(self, session: Session) -> None:
+        """Update session's last_active_at timestamp"""
+        session.update_activity()
+        self.db.commit()
+
+    def revoke_session(self, session_id: str, user_id: str) -> bool:
+        """
+        Revoke a specific session.
+
+        Args:
+            session_id: Session ID to revoke
+            user_id: User ID (for authorization check)
+
+        Returns:
+            True if session was revoked, False if not found
+        """
+        session = self.db.query(Session).filter(
+            Session.id == session_id,
+            Session.user_id == user_id
+        ).first()
+
+        if not session:
+            return False
+
+        self.db.delete(session)
+        self.db.commit()
+
+        logger.info(
+            "Session revoked",
+            extra={
+                "event_type": "session_revoked",
+                "user_id": user_id,
+                "session_id": session_id,
+            }
+        )
+
+        return True
+
+    def revoke_all_sessions(self, user_id: str, except_session_id: Optional[str] = None) -> int:
+        """
+        Revoke all sessions for a user, optionally keeping one.
+
+        Args:
+            user_id: User ID
+            except_session_id: Session ID to keep (current session)
+
+        Returns:
+            Number of sessions revoked
+        """
+        query = self.db.query(Session).filter(Session.user_id == user_id)
+
+        if except_session_id:
+            query = query.filter(Session.id != except_session_id)
+
+        sessions = query.all()
+        count = len(sessions)
+
+        for session in sessions:
+            self.db.delete(session)
+
+        self.db.commit()
+
+        logger.info(
+            "All sessions revoked",
+            extra={
+                "event_type": "all_sessions_revoked",
+                "user_id": user_id,
+                "revoked_count": count,
+                "kept_session_id": except_session_id,
+            }
+        )
+
+        return count
+
+    def get_user_sessions(
+        self,
+        user_id: str,
+        current_token: Optional[str] = None
+    ) -> List[dict]:
+        """
+        Get all active sessions for a user.
+
+        Args:
+            user_id: User ID
+            current_token: Current session's token (to mark is_current)
+
+        Returns:
+            List of session info dicts with is_current flag
+        """
+        sessions = self._get_user_sessions(user_id, valid_only=True)
+        current_hash = Session.hash_token(current_token) if current_token else None
+
+        result = []
+        for session in sessions:
+            result.append({
+                "id": session.id,
+                "device_info": session.device_info,
+                "ip_address": session.ip_address,
+                "created_at": session.created_at,
+                "last_active_at": session.last_active_at,
+                "is_current": session.token_hash == current_hash if current_hash else False,
+            })
+
+        return result
+
+    def cleanup_expired_sessions(self) -> int:
+        """
+        Delete all expired sessions from database.
+
+        Should be called by background task (hourly).
+
+        Returns:
+            Number of sessions cleaned up
+        """
+        now = datetime.now(timezone.utc)
+        expired = self.db.query(Session).filter(
+            Session.expires_at < now
+        ).all()
+
+        count = len(expired)
+        for session in expired:
+            self.db.delete(session)
+
+        self.db.commit()
+
+        if count > 0:
+            logger.info(
+                "Expired sessions cleaned up",
+                extra={
+                    "event_type": "sessions_cleanup",
+                    "expired_count": count,
+                }
+            )
+
+        return count
+
+    def _get_user_sessions(self, user_id: str, valid_only: bool = False) -> List[Session]:
+        """Get all sessions for a user, ordered by creation time (oldest first)"""
+        query = self.db.query(Session).filter(Session.user_id == user_id)
+
+        if valid_only:
+            now = datetime.now(timezone.utc)
+            query = query.filter(Session.expires_at > now)
+
+        return query.order_by(Session.created_at.asc()).all()
+
+    def _parse_device_info(self, request: Request) -> str:
+        """
+        Parse User-Agent into human-readable device info.
+
+        Examples:
+        - "Chrome on Windows"
+        - "Safari on iPhone"
+        - "Firefox on Linux"
+        """
+        user_agent = request.headers.get("User-Agent", "")
+        if not user_agent:
+            return "Unknown Device"
+
+        # Browser detection
+        browser = "Unknown Browser"
+        if "Chrome" in user_agent and "Safari" in user_agent and "Edg" not in user_agent:
+            browser = "Chrome"
+        elif "Firefox" in user_agent:
+            browser = "Firefox"
+        elif "Safari" in user_agent and "Chrome" not in user_agent:
+            browser = "Safari"
+        elif "Edg" in user_agent:
+            browser = "Edge"
+        elif "MSIE" in user_agent or "Trident" in user_agent:
+            browser = "Internet Explorer"
+
+        # OS detection
+        os = "Unknown OS"
+        if "Windows" in user_agent:
+            os = "Windows"
+        elif "Macintosh" in user_agent or "Mac OS" in user_agent:
+            os = "macOS"
+        elif "iPhone" in user_agent:
+            os = "iPhone"
+        elif "iPad" in user_agent:
+            os = "iPad"
+        elif "Android" in user_agent:
+            os = "Android"
+        elif "Linux" in user_agent:
+            os = "Linux"
+
+        return f"{browser} on {os}"
+
+    def _get_client_ip(self, request: Request) -> str:
+        """Extract client IP from request, checking forwarding headers"""
+        # Check X-Forwarded-For header (for proxied requests)
+        forwarded = request.headers.get("X-Forwarded-For", "")
+        if forwarded:
+            # Take the first IP (original client)
+            return forwarded.split(",")[0].strip()
+
+        # Check X-Real-IP header
+        real_ip = request.headers.get("X-Real-IP", "")
+        if real_ip:
+            return real_ip.strip()
+
+        # Fall back to direct client
+        if request.client:
+            return request.client.host
+
+        return "unknown"

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -1,0 +1,332 @@
+"""User management service (Story P15-2.3, P15-2.5)
+
+Provides user CRUD operations, invitation flow, and password reset functionality.
+"""
+from datetime import datetime, timezone, timedelta
+from typing import Optional, List, Tuple
+from sqlalchemy.orm import Session as DBSession
+from sqlalchemy.exc import IntegrityError
+import secrets
+import logging
+
+from app.models.user import User, UserRole
+from app.utils.auth import hash_password
+
+logger = logging.getLogger(__name__)
+
+# Temporary password expires after 72 hours
+TEMP_PASSWORD_EXPIRY_HOURS = 72
+
+# Password length for generated passwords
+GENERATED_PASSWORD_LENGTH = 16
+
+
+class UserService:
+    """
+    Service for managing users (Story P15-2.3, P15-2.5)
+
+    Responsibilities:
+    - Create users with temporary passwords (invitation flow)
+    - Update user details (admin operations)
+    - Reset passwords
+    - Enable/disable accounts
+    - Delete users
+    """
+
+    def __init__(self, db: DBSession):
+        self.db = db
+
+    def create_user(
+        self,
+        username: str,
+        role: str = "viewer",
+        email: Optional[str] = None,
+        send_email: bool = False
+    ) -> Tuple[User, str]:
+        """
+        Create a new user with temporary password.
+
+        Args:
+            username: Unique username
+            role: User role (admin, operator, viewer)
+            email: Optional email address
+            send_email: Whether to send invitation email (future feature)
+
+        Returns:
+            Tuple of (User, temporary_password)
+
+        Raises:
+            ValueError: If username already exists
+        """
+        # Generate secure random password
+        temp_password = self._generate_password()
+        password_hash = hash_password(temp_password)
+
+        # Calculate password expiry (72 hours)
+        password_expires_at = datetime.now(timezone.utc) + timedelta(hours=TEMP_PASSWORD_EXPIRY_HOURS)
+
+        # Create user with must_change_password flag
+        user = User(
+            username=username,
+            email=email,
+            password_hash=password_hash,
+            role=UserRole(role),
+            is_active=True,
+            must_change_password=True,
+            password_expires_at=password_expires_at,
+        )
+
+        try:
+            self.db.add(user)
+            self.db.commit()
+            self.db.refresh(user)
+        except IntegrityError as e:
+            self.db.rollback()
+            if "username" in str(e).lower():
+                raise ValueError(f"Username '{username}' already exists")
+            if "email" in str(e).lower():
+                raise ValueError(f"Email '{email}' already exists")
+            raise ValueError("Failed to create user")
+
+        logger.info(
+            "User created",
+            extra={
+                "event_type": "user_created",
+                "user_id": user.id,
+                "username": username,
+                "role": role,
+                "has_email": email is not None,
+            }
+        )
+
+        # TODO: If send_email and email is configured, send invitation email
+        # For now, we just return the password for display
+
+        return user, temp_password
+
+    def get_user(self, user_id: str) -> Optional[User]:
+        """Get user by ID"""
+        return self.db.query(User).filter(User.id == user_id).first()
+
+    def get_user_by_username(self, username: str) -> Optional[User]:
+        """Get user by username"""
+        return self.db.query(User).filter(User.username == username.lower()).first()
+
+    def list_users(self) -> List[User]:
+        """List all users"""
+        return self.db.query(User).order_by(User.created_at.desc()).all()
+
+    def update_user(
+        self,
+        user_id: str,
+        email: Optional[str] = None,
+        role: Optional[str] = None,
+        is_active: Optional[bool] = None
+    ) -> Optional[User]:
+        """
+        Update user details.
+
+        Args:
+            user_id: User ID to update
+            email: New email address
+            role: New role (admin, operator, viewer)
+            is_active: New active status
+
+        Returns:
+            Updated User or None if not found
+        """
+        user = self.get_user(user_id)
+        if not user:
+            return None
+
+        if email is not None:
+            user.email = email
+
+        if role is not None:
+            user.role = UserRole(role)
+
+        if is_active is not None:
+            user.is_active = is_active
+            # If disabling user, invalidate all their sessions
+            if not is_active:
+                self._invalidate_user_sessions(user_id)
+
+        try:
+            self.db.commit()
+            self.db.refresh(user)
+        except IntegrityError:
+            self.db.rollback()
+            raise ValueError("Email already exists")
+
+        logger.info(
+            "User updated",
+            extra={
+                "event_type": "user_updated",
+                "user_id": user_id,
+                "changes": {
+                    "email": email is not None,
+                    "role": role,
+                    "is_active": is_active,
+                }
+            }
+        )
+
+        return user
+
+    def delete_user(self, user_id: str) -> bool:
+        """
+        Delete a user.
+
+        Cascade deletes all associated sessions and devices.
+
+        Args:
+            user_id: User ID to delete
+
+        Returns:
+            True if deleted, False if not found
+        """
+        user = self.get_user(user_id)
+        if not user:
+            return False
+
+        username = user.username
+        self.db.delete(user)
+        self.db.commit()
+
+        logger.info(
+            "User deleted",
+            extra={
+                "event_type": "user_deleted",
+                "user_id": user_id,
+                "username": username,
+            }
+        )
+
+        return True
+
+    def reset_password(self, user_id: str) -> Tuple[Optional[str], Optional[datetime]]:
+        """
+        Reset user password to a temporary password.
+
+        Args:
+            user_id: User ID
+
+        Returns:
+            Tuple of (temp_password, expires_at) or (None, None) if user not found
+        """
+        user = self.get_user(user_id)
+        if not user:
+            return None, None
+
+        # Generate new temporary password
+        temp_password = self._generate_password()
+        password_hash = hash_password(temp_password)
+
+        # Set expiry (72 hours)
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=TEMP_PASSWORD_EXPIRY_HOURS)
+
+        # Update user
+        user.password_hash = password_hash
+        user.must_change_password = True
+        user.password_expires_at = expires_at
+
+        # Invalidate all existing sessions
+        self._invalidate_user_sessions(user_id)
+
+        self.db.commit()
+        self.db.refresh(user)
+
+        logger.info(
+            "Password reset",
+            extra={
+                "event_type": "password_reset",
+                "user_id": user_id,
+                "username": user.username,
+            }
+        )
+
+        return temp_password, expires_at
+
+    def change_password(
+        self,
+        user: User,
+        new_password: str,
+        clear_must_change: bool = True
+    ) -> None:
+        """
+        Change user's password.
+
+        Args:
+            user: User object
+            new_password: New password (already validated)
+            clear_must_change: Whether to clear must_change_password flag
+        """
+        user.password_hash = hash_password(new_password)
+
+        if clear_must_change:
+            user.must_change_password = False
+            user.password_expires_at = None
+
+        self.db.commit()
+        self.db.refresh(user)
+
+        logger.info(
+            "Password changed",
+            extra={
+                "event_type": "password_changed",
+                "user_id": user.id,
+                "username": user.username,
+            }
+        )
+
+    def _generate_password(self) -> str:
+        """Generate a secure random password"""
+        return secrets.token_urlsafe(GENERATED_PASSWORD_LENGTH)
+
+    def _invalidate_user_sessions(self, user_id: str) -> int:
+        """Invalidate all sessions for a user"""
+        from app.models.session import Session
+
+        sessions = self.db.query(Session).filter(Session.user_id == user_id).all()
+        count = len(sessions)
+
+        for session in sessions:
+            self.db.delete(session)
+
+        return count
+
+    def ensure_admin_exists(self) -> Tuple[bool, str]:
+        """
+        Ensure at least one admin user exists.
+
+        Creates default admin if no users exist.
+
+        Returns:
+            Tuple of (created, password) - password only if newly created
+        """
+        existing_users = self.db.query(User).count()
+        if existing_users > 0:
+            return False, ""
+
+        # Create default admin
+        user, password = self.create_user(
+            username="admin",
+            role="admin",
+            email=None,
+            send_email=False
+        )
+
+        # Admin doesn't need to change password on first login
+        user.must_change_password = False
+        user.password_expires_at = None
+        self.db.commit()
+
+        logger.info(
+            "Default admin created",
+            extra={
+                "event_type": "default_admin_created",
+                "user_id": user.id,
+            }
+        )
+
+        return True, password

--- a/backend/app/utils/auth.py
+++ b/backend/app/utils/auth.py
@@ -61,13 +61,14 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
 
 def validate_password_strength(password: str) -> tuple[bool, str]:
     """
-    Validate password meets security requirements
+    Validate password meets security requirements (Story P15-2.4)
 
-    Requirements:
-    - At least 8 characters
+    Requirements (per tech spec):
+    - Minimum 8 characters
     - At least 1 uppercase letter
+    - At least 1 lowercase letter
     - At least 1 number
-    - At least 1 special character
+    - At least 1 special character (!@#$%^&*()_+-=[]{}|;:,.<>?)
 
     Args:
         password: Password to validate
@@ -87,10 +88,13 @@ def validate_password_strength(password: str) -> tuple[bool, str]:
     if not re.search(r'[A-Z]', password):
         return False, "Password must contain at least one uppercase letter"
 
+    if not re.search(r'[a-z]', password):
+        return False, "Password must contain at least one lowercase letter"
+
     if not re.search(r'[0-9]', password):
         return False, "Password must contain at least one number"
 
-    if not re.search(r'[!@#$%^&*(),.?":{}|<>_\-+=\[\]\\;\'`~]', password):
+    if not re.search(r'[!@#$%^&*()_+\-=\[\]{}|;:,.<>?]', password):
         return False, "Password must contain at least one special character"
 
     return True, ""

--- a/frontend/components/settings/SessionManagement.tsx
+++ b/frontend/components/settings/SessionManagement.tsx
@@ -1,0 +1,273 @@
+/**
+ * Session Management Component (Story P15-2.7)
+ *
+ * Displays active sessions and allows revoking them.
+ * Features:
+ * - List all active sessions with device info
+ * - Mark current session
+ * - Revoke individual sessions
+ * - Revoke all other sessions
+ */
+
+'use client';
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import {
+  Monitor,
+  Smartphone,
+  Laptop,
+  Tablet,
+  Globe,
+  Clock,
+  MapPin,
+  Trash2,
+  LogOut,
+  Loader2,
+  Check,
+} from 'lucide-react';
+
+import { apiClient } from '@/lib/api-client';
+import type { ISession } from '@/types/auth';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+// Determine icon based on device info
+function getDeviceIcon(deviceInfo: string | null) {
+  if (!deviceInfo) return Monitor;
+
+  const info = deviceInfo.toLowerCase();
+  if (info.includes('iphone') || info.includes('android')) return Smartphone;
+  if (info.includes('ipad') || info.includes('tablet')) return Tablet;
+  if (info.includes('macos') || info.includes('windows') || info.includes('linux')) return Laptop;
+  return Monitor;
+}
+
+function formatRelativeTime(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMins < 1) return 'Just now';
+  if (diffMins < 60) return `${diffMins} minute${diffMins === 1 ? '' : 's'} ago`;
+  if (diffHours < 24) return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+  if (diffDays < 7) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+  return date.toLocaleDateString();
+}
+
+export function SessionManagement() {
+  const queryClient = useQueryClient();
+
+  // Fetch sessions
+  const { data: sessions, isLoading } = useQuery({
+    queryKey: ['sessions'],
+    queryFn: () => apiClient.auth.listSessions(),
+  });
+
+  // Revoke single session
+  const revokeSessionMutation = useMutation({
+    mutationFn: (sessionId: string) => apiClient.auth.revokeSession(sessionId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['sessions'] });
+      toast.success('Session revoked successfully');
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to revoke session');
+    },
+  });
+
+  // Revoke all other sessions
+  const revokeAllMutation = useMutation({
+    mutationFn: () => apiClient.auth.revokeAllSessions(),
+    onSuccess: (response) => {
+      queryClient.invalidateQueries({ queryKey: ['sessions'] });
+      toast.success(`${response.revoked_count} session${response.revoked_count === 1 ? '' : 's'} revoked`);
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to revoke sessions');
+    },
+  });
+
+  const otherSessionsCount = sessions?.filter(s => !s.is_current).length || 0;
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center py-8">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+        <div>
+          <CardTitle className="flex items-center gap-2">
+            <Globe className="h-5 w-5" />
+            Active Sessions
+          </CardTitle>
+          <CardDescription>
+            Manage your active login sessions across devices
+          </CardDescription>
+        </div>
+        {otherSessionsCount > 0 && (
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="outline" size="sm">
+                <LogOut className="h-4 w-4 mr-2" />
+                Sign Out All Others
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Sign Out All Other Sessions</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This will sign out all {otherSessionsCount} other active session{otherSessionsCount === 1 ? '' : 's'}.
+                  Your current session will remain active.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={() => revokeAllMutation.mutate()}
+                  disabled={revokeAllMutation.isPending}
+                >
+                  {revokeAllMutation.isPending ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  ) : (
+                    <LogOut className="h-4 w-4 mr-2" />
+                  )}
+                  Sign Out All
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        )}
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {sessions?.map((session) => {
+            const DeviceIcon = getDeviceIcon(session.device_info);
+            return (
+              <div
+                key={session.id}
+                className={`flex items-center justify-between p-4 rounded-lg border ${
+                  session.is_current
+                    ? 'border-green-500/30 bg-green-500/5'
+                    : 'border-border bg-muted/30'
+                }`}
+              >
+                <div className="flex items-center gap-4">
+                  <div className={`p-2 rounded-lg ${
+                    session.is_current ? 'bg-green-500/10' : 'bg-muted'
+                  }`}>
+                    <DeviceIcon className={`h-5 w-5 ${
+                      session.is_current ? 'text-green-500' : 'text-muted-foreground'
+                    }`} />
+                  </div>
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium">
+                        {session.device_info || 'Unknown Device'}
+                      </span>
+                      {session.is_current && (
+                        <Badge className="bg-green-500/10 text-green-500 hover:bg-green-500/20">
+                          <Check className="h-3 w-3 mr-1" />
+                          Current
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-4 mt-1 text-sm text-muted-foreground">
+                      {session.ip_address && (
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger className="flex items-center gap-1">
+                              <MapPin className="h-3 w-3" />
+                              {session.ip_address}
+                            </TooltipTrigger>
+                            <TooltipContent>IP Address</TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      )}
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger className="flex items-center gap-1">
+                            <Clock className="h-3 w-3" />
+                            {formatRelativeTime(session.last_active_at)}
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            Last active: {new Date(session.last_active_at).toLocaleString()}
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    </div>
+                  </div>
+                </div>
+                {!session.is_current && (
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-muted-foreground hover:text-destructive"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Revoke Session</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          This will sign out the session on {session.device_info || 'this device'}.
+                          The user will need to log in again.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                          className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                          onClick={() => revokeSessionMutation.mutate(session.id)}
+                        >
+                          Revoke
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                )}
+              </div>
+            );
+          })}
+          {(!sessions || sessions.length === 0) && (
+            <div className="text-center text-muted-foreground py-8">
+              No active sessions found
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/settings/UserManagement.tsx
+++ b/frontend/components/settings/UserManagement.tsx
@@ -1,0 +1,605 @@
+/**
+ * User Management Component (Story P15-2.10)
+ *
+ * Admin-only component for managing user accounts.
+ * Features:
+ * - Create new users with temporary passwords
+ * - Edit user roles and status
+ * - Reset passwords
+ * - Delete users
+ */
+
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import {
+  Users,
+  Plus,
+  Pencil,
+  Trash2,
+  Key,
+  Copy,
+  Check,
+  X,
+  Shield,
+  Eye,
+  UserCog,
+  Loader2,
+} from 'lucide-react';
+
+import { apiClient } from '@/lib/api-client';
+import type { IUser, IUserCreate, IUserCreateResponse, UserRole } from '@/types/auth';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+interface UserManagementProps {
+  currentUserId: string;
+}
+
+const roleIcons: Record<UserRole, React.ElementType> = {
+  admin: Shield,
+  operator: UserCog,
+  viewer: Eye,
+};
+
+const roleColors: Record<UserRole, string> = {
+  admin: 'bg-purple-500/10 text-purple-500 hover:bg-purple-500/20',
+  operator: 'bg-blue-500/10 text-blue-500 hover:bg-blue-500/20',
+  viewer: 'bg-gray-500/10 text-gray-500 hover:bg-gray-500/20',
+};
+
+const roleDescriptions: Record<UserRole, string> = {
+  admin: 'Full system access including user management',
+  operator: 'Manage events, entities, cameras but not users',
+  viewer: 'Read-only access to dashboard and events',
+};
+
+export function UserManagement({ currentUserId }: UserManagementProps) {
+  const queryClient = useQueryClient();
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [editingUser, setEditingUser] = useState<IUser | null>(null);
+  const [temporaryPassword, setTemporaryPassword] = useState<string | null>(null);
+  const [copiedPassword, setCopiedPassword] = useState(false);
+
+  // Form state for creating new user
+  const [newUsername, setNewUsername] = useState('');
+  const [newEmail, setNewEmail] = useState('');
+  const [newRole, setNewRole] = useState<UserRole>('viewer');
+
+  // Form state for editing user
+  const [editEmail, setEditEmail] = useState('');
+  const [editRole, setEditRole] = useState<UserRole>('viewer');
+  const [editIsActive, setEditIsActive] = useState(true);
+
+  // Fetch users
+  const { data: users, isLoading } = useQuery({
+    queryKey: ['users'],
+    queryFn: () => apiClient.users.list(),
+  });
+
+  // Create user mutation
+  const createUserMutation = useMutation({
+    mutationFn: (data: IUserCreate) => apiClient.users.create(data),
+    onSuccess: (response: IUserCreateResponse) => {
+      queryClient.invalidateQueries({ queryKey: ['users'] });
+      setTemporaryPassword(response.temporary_password);
+      setNewUsername('');
+      setNewEmail('');
+      setNewRole('viewer');
+      toast.success(`User "${response.username}" created successfully`);
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to create user');
+    },
+  });
+
+  // Update user mutation
+  const updateUserMutation = useMutation({
+    mutationFn: ({ userId, data }: { userId: string; data: { email?: string; role?: UserRole; is_active?: boolean } }) =>
+      apiClient.users.update(userId, data),
+    onSuccess: (user) => {
+      queryClient.invalidateQueries({ queryKey: ['users'] });
+      setIsEditDialogOpen(false);
+      setEditingUser(null);
+      toast.success(`User "${user.username}" updated successfully`);
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to update user');
+    },
+  });
+
+  // Delete user mutation
+  const deleteUserMutation = useMutation({
+    mutationFn: (userId: string) => apiClient.users.delete(userId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['users'] });
+      toast.success('User deleted successfully');
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to delete user');
+    },
+  });
+
+  // Reset password mutation
+  const resetPasswordMutation = useMutation({
+    mutationFn: (userId: string) => apiClient.users.resetPassword(userId),
+    onSuccess: (response, userId) => {
+      const user = users?.find(u => u.id === userId);
+      toast.success(`Password reset for "${user?.username || 'user'}"`);
+      setTemporaryPassword(response.temporary_password);
+      setIsCreateDialogOpen(true); // Reuse dialog to show password
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to reset password');
+    },
+  });
+
+  const handleCreateUser = () => {
+    if (!newUsername.trim()) {
+      toast.error('Username is required');
+      return;
+    }
+    createUserMutation.mutate({
+      username: newUsername.trim(),
+      email: newEmail.trim() || undefined,
+      role: newRole,
+    });
+  };
+
+  const handleEditUser = (user: IUser) => {
+    setEditingUser(user);
+    setEditEmail(user.email || '');
+    setEditRole(user.role);
+    setEditIsActive(user.is_active);
+    setIsEditDialogOpen(true);
+  };
+
+  const handleUpdateUser = () => {
+    if (!editingUser) return;
+    updateUserMutation.mutate({
+      userId: editingUser.id,
+      data: {
+        email: editEmail.trim() || undefined,
+        role: editRole,
+        is_active: editIsActive,
+      },
+    });
+  };
+
+  const copyPassword = async () => {
+    if (temporaryPassword) {
+      await navigator.clipboard.writeText(temporaryPassword);
+      setCopiedPassword(true);
+      setTimeout(() => setCopiedPassword(false), 2000);
+    }
+  };
+
+  const closeCreateDialog = () => {
+    setIsCreateDialogOpen(false);
+    setTemporaryPassword(null);
+    setCopiedPassword(false);
+  };
+
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return 'Never';
+    return new Date(dateString).toLocaleString();
+  };
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center py-8">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+        <div>
+          <CardTitle className="flex items-center gap-2">
+            <Users className="h-5 w-5" />
+            User Management
+          </CardTitle>
+          <CardDescription>
+            Manage user accounts and permissions
+          </CardDescription>
+        </div>
+        <Dialog open={isCreateDialogOpen} onOpenChange={(open) => {
+          if (!open) closeCreateDialog();
+          else setIsCreateDialogOpen(true);
+        }}>
+          <DialogTrigger asChild>
+            <Button size="sm">
+              <Plus className="h-4 w-4 mr-2" />
+              Add User
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>
+                {temporaryPassword ? 'User Created' : 'Create New User'}
+              </DialogTitle>
+              <DialogDescription>
+                {temporaryPassword
+                  ? 'Save this temporary password - it will not be shown again.'
+                  : 'Create a new user account with a temporary password.'}
+              </DialogDescription>
+            </DialogHeader>
+            {temporaryPassword ? (
+              <div className="space-y-4">
+                <div className="p-4 bg-yellow-500/10 border border-yellow-500/20 rounded-lg">
+                  <p className="text-sm text-yellow-600 dark:text-yellow-400 font-medium mb-2">
+                    Temporary Password
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <code className="flex-1 p-2 bg-muted rounded font-mono text-sm">
+                      {temporaryPassword}
+                    </code>
+                    <Button variant="outline" size="icon" onClick={copyPassword}>
+                      {copiedPassword ? (
+                        <Check className="h-4 w-4 text-green-500" />
+                      ) : (
+                        <Copy className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-2">
+                    This password expires in 72 hours. User must change it on first login.
+                  </p>
+                </div>
+                <DialogFooter>
+                  <Button onClick={closeCreateDialog}>Done</Button>
+                </DialogFooter>
+              </div>
+            ) : (
+              <>
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="username">Username</Label>
+                    <Input
+                      id="username"
+                      placeholder="Enter username"
+                      value={newUsername}
+                      onChange={(e) => setNewUsername(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="email">Email (optional)</Label>
+                    <Input
+                      id="email"
+                      type="email"
+                      placeholder="Enter email"
+                      value={newEmail}
+                      onChange={(e) => setNewEmail(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="role">Role</Label>
+                    <Select value={newRole} onValueChange={(v) => setNewRole(v as UserRole)}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="admin">
+                          <div className="flex items-center gap-2">
+                            <Shield className="h-4 w-4" />
+                            Admin
+                          </div>
+                        </SelectItem>
+                        <SelectItem value="operator">
+                          <div className="flex items-center gap-2">
+                            <UserCog className="h-4 w-4" />
+                            Operator
+                          </div>
+                        </SelectItem>
+                        <SelectItem value="viewer">
+                          <div className="flex items-center gap-2">
+                            <Eye className="h-4 w-4" />
+                            Viewer
+                          </div>
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                      {roleDescriptions[newRole]}
+                    </p>
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => setIsCreateDialogOpen(false)}>
+                    Cancel
+                  </Button>
+                  <Button
+                    onClick={handleCreateUser}
+                    disabled={createUserMutation.isPending}
+                  >
+                    {createUserMutation.isPending && (
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    )}
+                    Create User
+                  </Button>
+                </DialogFooter>
+              </>
+            )}
+          </DialogContent>
+        </Dialog>
+      </CardHeader>
+      <CardContent>
+        <TooltipProvider>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Username</TableHead>
+                <TableHead>Email</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Last Login</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {users?.map((user) => {
+                const RoleIcon = roleIcons[user.role];
+                const isCurrentUser = user.id === currentUserId;
+                return (
+                  <TableRow key={user.id}>
+                    <TableCell className="font-medium">
+                      {user.username}
+                      {isCurrentUser && (
+                        <Badge variant="outline" className="ml-2 text-xs">
+                          You
+                        </Badge>
+                      )}
+                      {user.must_change_password && (
+                        <Badge variant="secondary" className="ml-2 text-xs">
+                          Password Change Required
+                        </Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {user.email || '-'}
+                    </TableCell>
+                    <TableCell>
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <Badge className={roleColors[user.role]}>
+                            <RoleIcon className="h-3 w-3 mr-1" />
+                            {user.role.charAt(0).toUpperCase() + user.role.slice(1)}
+                          </Badge>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {roleDescriptions[user.role]}
+                        </TooltipContent>
+                      </Tooltip>
+                    </TableCell>
+                    <TableCell>
+                      {user.is_active ? (
+                        <Badge variant="outline" className="text-green-500 border-green-500/20 bg-green-500/10">
+                          <Check className="h-3 w-3 mr-1" />
+                          Active
+                        </Badge>
+                      ) : (
+                        <Badge variant="outline" className="text-red-500 border-red-500/20 bg-red-500/10">
+                          <X className="h-3 w-3 mr-1" />
+                          Inactive
+                        </Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm">
+                      {formatDate(user.last_login)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex items-center justify-end gap-1">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => handleEditUser(user)}
+                              disabled={isCurrentUser}
+                            >
+                              <Pencil className="h-4 w-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            {isCurrentUser ? 'Cannot edit yourself' : 'Edit user'}
+                          </TooltipContent>
+                        </Tooltip>
+
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => resetPasswordMutation.mutate(user.id)}
+                              disabled={resetPasswordMutation.isPending}
+                            >
+                              <Key className="h-4 w-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Reset password</TooltipContent>
+                        </Tooltip>
+
+                        <AlertDialog>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <AlertDialogTrigger asChild>
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  className="text-destructive hover:text-destructive"
+                                  disabled={isCurrentUser}
+                                >
+                                  <Trash2 className="h-4 w-4" />
+                                </Button>
+                              </AlertDialogTrigger>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              {isCurrentUser ? 'Cannot delete yourself' : 'Delete user'}
+                            </TooltipContent>
+                          </Tooltip>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>Delete User</AlertDialogTitle>
+                              <AlertDialogDescription>
+                                Are you sure you want to delete &quot;{user.username}&quot;?
+                                This action cannot be undone.
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>Cancel</AlertDialogCancel>
+                              <AlertDialogAction
+                                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                                onClick={() => deleteUserMutation.mutate(user.id)}
+                              >
+                                Delete
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+              {(!users || users.length === 0) && (
+                <TableRow>
+                  <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
+                    No users found
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TooltipProvider>
+      </CardContent>
+
+      {/* Edit User Dialog */}
+      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit User</DialogTitle>
+            <DialogDescription>
+              Update user details for &quot;{editingUser?.username}&quot;
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="edit-email">Email</Label>
+              <Input
+                id="edit-email"
+                type="email"
+                placeholder="Enter email"
+                value={editEmail}
+                onChange={(e) => setEditEmail(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-role">Role</Label>
+              <Select value={editRole} onValueChange={(v) => setEditRole(v as UserRole)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="admin">
+                    <div className="flex items-center gap-2">
+                      <Shield className="h-4 w-4" />
+                      Admin
+                    </div>
+                  </SelectItem>
+                  <SelectItem value="operator">
+                    <div className="flex items-center gap-2">
+                      <UserCog className="h-4 w-4" />
+                      Operator
+                    </div>
+                  </SelectItem>
+                  <SelectItem value="viewer">
+                    <div className="flex items-center gap-2">
+                      <Eye className="h-4 w-4" />
+                      Viewer
+                    </div>
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                {roleDescriptions[editRole]}
+              </p>
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label>Account Status</Label>
+                <p className="text-xs text-muted-foreground">
+                  Inactive users cannot log in
+                </p>
+              </div>
+              <Switch
+                checked={editIsActive}
+                onCheckedChange={setEditIsActive}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsEditDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleUpdateUser}
+              disabled={updateUserMutation.isPending}
+            >
+              {updateUserMutation.isPending && (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              )}
+              Save Changes
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -70,6 +70,12 @@ import type {
   IChangePasswordRequest,
   IMessageResponse,
   ISetupStatusResponse,
+  IUserCreate,
+  IUserCreateResponse,
+  IUserUpdate,
+  IPasswordResetResponse,
+  ISession,
+  ISessionRevokeResponse,
 } from '@/types/auth';
 import type {
   IBackupResponse,
@@ -1091,6 +1097,102 @@ export const apiClient = {
       return apiFetch('/auth/setup', {
         method: 'POST',
         body: JSON.stringify(request),
+      });
+    },
+
+    // Session Management (Story P15-2.7)
+
+    /**
+     * List all active sessions for current user
+     * @returns List of sessions with current session marked
+     */
+    listSessions: async (): Promise<ISession[]> => {
+      return apiFetch('/auth/sessions');
+    },
+
+    /**
+     * Revoke a specific session
+     * @param sessionId Session ID to revoke
+     */
+    revokeSession: async (sessionId: string): Promise<void> => {
+      return apiFetch(`/auth/sessions/${sessionId}`, {
+        method: 'DELETE',
+      });
+    },
+
+    /**
+     * Revoke all sessions except current
+     * @returns Number of sessions revoked
+     */
+    revokeAllSessions: async (): Promise<ISessionRevokeResponse> => {
+      return apiFetch('/auth/sessions', {
+        method: 'DELETE',
+      });
+    },
+  },
+
+  // User Management (Story P15-2.3)
+  users: {
+    /**
+     * Create a new user (admin only)
+     * @param request User creation request
+     * @returns Created user with temporary password
+     */
+    create: async (request: IUserCreate): Promise<IUserCreateResponse> => {
+      return apiFetch('/users', {
+        method: 'POST',
+        body: JSON.stringify(request),
+      });
+    },
+
+    /**
+     * List all users (admin only)
+     * @returns List of all users
+     */
+    list: async (): Promise<IUser[]> => {
+      return apiFetch('/users');
+    },
+
+    /**
+     * Get a specific user by ID (admin only)
+     * @param userId User ID
+     * @returns User details
+     */
+    get: async (userId: string): Promise<IUser> => {
+      return apiFetch(`/users/${userId}`);
+    },
+
+    /**
+     * Update a user (admin only)
+     * @param userId User ID
+     * @param request Update request
+     * @returns Updated user
+     */
+    update: async (userId: string, request: IUserUpdate): Promise<IUser> => {
+      return apiFetch(`/users/${userId}`, {
+        method: 'PUT',
+        body: JSON.stringify(request),
+      });
+    },
+
+    /**
+     * Delete a user (admin only)
+     * @param userId User ID
+     */
+    delete: async (userId: string): Promise<void> => {
+      return apiFetch(`/users/${userId}`, {
+        method: 'DELETE',
+      });
+    },
+
+    /**
+     * Reset a user's password (admin only)
+     * @param userId User ID
+     * @returns New temporary password and expiry
+     */
+    resetPassword: async (userId: string): Promise<IPasswordResetResponse> => {
+      return apiFetch(`/users/${userId}/reset`, {
+        method: 'POST',
       });
     },
   },

--- a/frontend/types/auth.ts
+++ b/frontend/types/auth.ts
@@ -1,11 +1,16 @@
 /**
- * Authentication types for frontend
+ * Authentication types for frontend (Story P15-2)
  */
+
+export type UserRole = 'admin' | 'operator' | 'viewer';
 
 export interface IUser {
   id: string;
   username: string;
+  email: string | null;
+  role: UserRole;
   is_active: boolean;
+  must_change_password: boolean;
   created_at: string;
   last_login: string | null;
 }
@@ -19,10 +24,11 @@ export interface ILoginResponse {
   access_token: string;
   token_type: string;
   user: IUser;
+  must_change_password: boolean;
 }
 
 export interface IChangePasswordRequest {
-  current_password: string;
+  current_password?: string;  // Optional for forced password changes
   new_password: string;
 }
 
@@ -33,4 +39,47 @@ export interface IMessageResponse {
 export interface ISetupStatusResponse {
   setup_complete: boolean;
   user_count: number;
+}
+
+// User Management Types (Story P15-2.3)
+export interface IUserCreate {
+  username: string;
+  email?: string;
+  role: UserRole;
+  send_email?: boolean;
+}
+
+export interface IUserCreateResponse {
+  id: string;
+  username: string;
+  email: string | null;
+  role: UserRole;
+  temporary_password: string | null;
+  password_expires_at: string | null;
+  created_at: string;
+}
+
+export interface IUserUpdate {
+  email?: string;
+  role?: UserRole;
+  is_active?: boolean;
+}
+
+export interface IPasswordResetResponse {
+  temporary_password: string;
+  expires_at: string;
+}
+
+// Session Management Types (Story P15-2.7)
+export interface ISession {
+  id: string;
+  device_info: string | null;
+  ip_address: string | null;
+  created_at: string;
+  last_active_at: string;
+  is_current: boolean;
+}
+
+export interface ISessionRevokeResponse {
+  revoked_count: number;
 }


### PR DESCRIPTION
## Summary

Complete implementation of Epic P15-2: Authentication & User Management

This PR implements a multi-user authentication system with role-based access control (RBAC):

### Backend Changes
- **User Model**: Extended with email, role (admin/operator/viewer), must_change_password, password_expires_at fields
- **Session Model**: New model for server-side session tracking with token hashing
- **User CRUD API**: POST/GET/PUT/DELETE /api/v1/users endpoints with admin-only access
- **Password Security**: bcrypt hashing with strength validation (12+ chars, upper, lower, digit, special)
- **User Invitation**: Temporary passwords with 72-hour expiry
- **Session Management**: List, revoke individual, revoke all other sessions
- **Session Cleanup**: Hourly scheduled job, 24-hour session expiry, max 5 sessions per user
- **RBAC Permissions**: Decorator-based role checking with require_admin, require_role

### Frontend Changes
- **UserManagement Component**: Admin-only table with create/edit/delete/reset-password
- **SessionManagement Component**: List active sessions, revoke functionality
- **AuthContext**: Added isAdmin, isOperator, isViewer, canManageUsers checks
- **Settings Page**: New "Users" tab visible only to admins

### Stories Completed
- [x] P15-2.1: User model and database schema
- [x] P15-2.2: Session model and tracking
- [x] P15-2.3: User CRUD API endpoints
- [x] P15-2.4: Password hashing and validation
- [x] P15-2.5: User invitation flow
- [x] P15-2.6: Force password change on first login
- [x] P15-2.7: Session management API
- [x] P15-2.8: Session expiration and limits
- [x] P15-2.9: Role-based access control backend
- [x] P15-2.10: User management UI

## Test Plan

- [ ] Verify migration applies cleanly: `alembic upgrade head`
- [ ] Test admin can create new users via Settings > Users
- [ ] Test temporary password is generated and displayed
- [ ] Test new user must change password on first login
- [ ] Test session list shows current device with "Current" badge
- [ ] Test revoking other sessions works
- [ ] Test non-admin users cannot see Users tab
- [ ] Test password validation rejects weak passwords

## Files Changed

**Backend (12 files)**
- `backend/app/models/user.py` - Extended User model
- `backend/app/models/session.py` - NEW: Session model
- `backend/app/services/user_service.py` - NEW: User CRUD operations
- `backend/app/services/session_service.py` - NEW: Session management
- `backend/app/api/v1/users.py` - NEW: User management endpoints
- `backend/app/api/v1/auth.py` - Session tracking, password change flow
- `backend/app/core/permissions.py` - NEW: RBAC decorators
- `backend/app/schemas/auth.py` - New request/response schemas
- `backend/alembic/versions/g1a2b3c4d5e6_*.py` - NEW: Migration

**Frontend (6 files)**
- `frontend/components/settings/UserManagement.tsx` - NEW
- `frontend/components/settings/SessionManagement.tsx` - NEW
- `frontend/contexts/AuthContext.tsx` - Role checks
- `frontend/lib/api-client.ts` - API methods
- `frontend/types/auth.ts` - Type definitions
- `frontend/app/settings/page.tsx` - Users tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)