### PR TITLE
feat(P16-2.5): Implement Concurrent Stream Limiting

### DIFF
--- a/docs/sprint-artifacts/P16-2.5.md
+++ b/docs/sprint-artifacts/P16-2.5.md
@@ -1,0 +1,145 @@
+# Story P16-2.5: Implement Concurrent Stream Limiting
+
+Status: done
+
+## Story
+
+As a **system administrator**,
+I want **concurrent streams limited**,
+So that **bandwidth is not exhausted**.
+
+## Acceptance Criteria
+
+1. **Given** 10 streams are currently active (default limit)
+   **When** a user tries to open an 11th stream
+   **Then** they receive error "Maximum concurrent streams reached. Please close another stream first."
+
+2. **Given** a stream is closed (modal closed or tab navigated away)
+   **When** the WebSocket disconnects
+   **Then** the stream count decrements
+   **And** another user can now open a stream
+
+3. **Given** STREAM_MAX_CONCURRENT is set to 5
+   **When** the system starts
+   **Then** the limit is enforced at 5 concurrent streams
+
+4. **And** admin can see current stream count in Settings > System (optional)
+
+## Tasks / Subtasks
+
+- [x] Task 1: Improve backend error messaging (AC: 1)
+  - [x] Differentiate "limit reached" from "camera unavailable" in WebSocket close
+  - [x] Return specific error code 4429 for limit reached (like HTTP 429)
+  - [x] Check `is_available` before `add_client` for early failure
+
+- [x] Task 2: Add frontend error handling in LiveStreamPlayer (AC: 1, 2)
+  - [x] Handle WebSocket close code 4429 specifically
+  - [x] Show toast notification "Maximum concurrent streams reached..."
+  - [x] Provide clear user feedback when stream connection fails due to limit
+
+- [x] Task 3: Add stream metrics to Settings > System (AC: 4 - optional)
+  - [x] Skipped - settings page already large, metrics available via /stream/info API
+
+- [x] Task 4: Write tests (AC: all)
+  - [x] Backend: TestConcurrentStreamLimiting class with 5 tests
+  - [x] Frontend: "Concurrent Stream Limiting (Story P16-2.5)" describe block with 4 tests
+
+## Dev Notes
+
+### Technical Context
+
+- **Epic**: P16-2 - Live Camera Streaming
+- **GitHub Issue**: TBD
+- **FRs Covered**: FR21 (multiple streams), FR17 (<3s latency)
+- **Prerequisites**: P16-2.2 (StreamProxyService) - ALREADY IMPLEMENTED
+
+### Existing Implementation Analysis
+
+The backend concurrent limiting is **already fully implemented** in P16-2.2:
+
+**StreamProxyService** (`backend/app/services/stream_proxy_service.py`):
+- `_max_concurrent = settings.STREAM_MAX_CONCURRENT` (line 120)
+- `add_client()` returns `None` when `_total_clients >= _max_concurrent` (lines 190-198)
+- `remove_client()` decrements `_total_clients` (line 257)
+- `get_stream_info()` returns `is_available` and `max_clients_available` (lines 165-167)
+
+**WebSocket endpoint** (`backend/app/api/v1/cameras.py:2318-2495`):
+- Already handles `add_client()` returning `None` (lines 2375-2382)
+- Sends: `{"type": "error", "message": "Maximum concurrent streams reached or camera unavailable"}`
+- Closes with code 4503
+
+### What's Actually Missing
+
+1. **Error differentiation**: Currently "limit reached" and "camera unavailable" are combined
+2. **Specific error code**: Use 4429 (like HTTP 429) for rate limiting
+3. **Frontend handling**: LiveStreamPlayer needs to handle limit errors gracefully
+4. **Settings UI**: Optional display of current stream usage
+
+### Implementation Approach
+
+**Backend Changes:**
+- Add new WebSocket close code 4429 for "limit reached"
+- Keep 4503 for "camera unavailable"
+- Add `reason` field to error JSON to help frontend
+
+**Frontend Changes:**
+- Handle code 4429 in LiveStreamPlayer WebSocket onclose
+- Show toast with specific message
+- Optional: Add StreamingMetrics to Settings
+
+### WebSocket Close Codes
+
+| Code | Meaning |
+|------|---------|
+| 4004 | Camera not found |
+| 4400 | Camera has no RTSP URL |
+| 4429 | Concurrent stream limit reached (NEW) |
+| 4503 | Stream unavailable |
+
+### Config Reference
+
+```python
+# backend/app/core/config.py
+STREAM_MAX_CONCURRENT: int = 10  # Max concurrent streams server-wide
+```
+
+### References
+
+- [Source: docs/epics-phase16.md#Story-P16-2.5]
+- [Source: backend/app/services/stream_proxy_service.py - Existing limit implementation]
+- [Source: backend/app/api/v1/cameras.py:2318-2495 - WebSocket endpoint]
+
+## Dev Agent Record
+
+### Context Reference
+
+<!-- Path(s) to story context XML will be added here by context workflow -->
+
+### Agent Model Used
+
+Claude Opus 4.5
+
+### Debug Log References
+
+### Completion Notes List
+
+- Backend already had limit enforcement in StreamProxyService; added early check and 4429 close code
+- Frontend LiveStreamPlayer updated to handle specific WebSocket close codes
+- Added toast notification for stream limit errors using existing useToast hook
+- Skipped optional Settings UI since metrics available via API
+- All backend tests pass (33 tests including 5 new for P16-2.5)
+- All frontend tests pass (22 tests including 4 new for P16-2.5)
+
+### File List
+
+- `backend/app/api/v1/cameras.py` - Added check for is_available before add_client, new 4429 close code
+- `frontend/components/streaming/LiveStreamPlayer.tsx` - Added WebSocket close code handling with toast
+- `frontend/__tests__/components/streaming/LiveStreamPlayer.test.tsx` - Added concurrent limit tests
+- `backend/tests/test_services/test_stream_proxy_service.py` - Added TestConcurrentStreamLimiting class
+- `docs/sprint-artifacts/P16-2.5.md` - Story file
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-01-01 | Story created | Claude Code |


### PR DESCRIPTION
## Summary

- Add user-friendly error handling when concurrent stream limit is reached
- Use WebSocket close code 4429 (like HTTP 429) for limit errors vs 4503 for unavailable
- Frontend displays toast notification and clear error message with retry button

## Changes

### Backend
- Check `is_available` before `add_client` for early failure detection
- Return WebSocket close code 4429 for limit reached
- Return specific error code and message in JSON before close

### Frontend  
- Handle specific WebSocket close codes (4429, 4004, 4400, 4503)
- Show toast notification using existing useToast hook
- Display error message in player with retry button

### Tests
- Backend: TestConcurrentStreamLimiting class with 5 tests
- Frontend: "Concurrent Stream Limiting (Story P16-2.5)" describe block with 4 tests

## Test plan

- [ ] Open multiple live stream modals until limit is reached (default: 10)
- [ ] Verify toast notification appears: "Maximum concurrent streams reached..."
- [ ] Verify error overlay shows with message and retry button
- [ ] Close one stream and verify new stream can be opened
- [ ] Run backend tests: `pytest tests/test_services/test_stream_proxy_service.py -v`
- [ ] Run frontend tests: `npm test -- --run __tests__/components/streaming/LiveStreamPlayer.test.tsx`

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)