### PR TITLE
feat(P16-3.1): Add entity_type and notes validation to Entity Update API

### DIFF
--- a/backend/app/services/entity_service.py
+++ b/backend/app/services/entity_service.py
@@ -1168,18 +1168,22 @@ class EntityService:
         db: Session,
         entity_id: str,
         name: Optional[str] = None,
+        entity_type: Optional[str] = None,
         notes: Optional[str] = None,
         is_vip: Optional[bool] = None,
         is_blocked: Optional[bool] = None,
     ) -> Optional[dict]:
         """
-        Update an entity's name, notes, VIP status, or blocked status.
+        Update an entity's metadata.
+
+        Story P16-3.1: Create Entity Update API Endpoint
 
         Args:
             db: SQLAlchemy database session
             entity_id: UUID of the entity
-            name: New name for the entity (None to clear)
-            notes: New notes for the entity (None to clear)
+            name: New name for the entity (None to keep unchanged)
+            entity_type: Entity type (person, vehicle, unknown) (None to keep unchanged)
+            notes: New notes for the entity (None to keep unchanged)
             is_vip: VIP status (None to keep unchanged)
             is_blocked: Blocked status (None to keep unchanged)
 
@@ -1198,6 +1202,8 @@ class EntityService:
         # Update provided fields
         if name is not None:
             entity.name = name
+        if entity_type is not None:
+            entity.entity_type = entity_type
         if notes is not None:
             entity.notes = notes
         if is_vip is not None:

--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -1135,7 +1135,7 @@ development_status:
   # GitHub: #338
   # FRs Covered: FR23-FR29
   epic-p16-3: contexted
-  p16-3-1-create-entity-update-api-endpoint: in-progress
+  p16-3-1-create-entity-update-api-endpoint: done
   p16-3-2-create-entityeditmodal-component: backlog
   p16-3-3-add-edit-button-to-entity-card: backlog
   p16-3-4-add-edit-button-to-entity-detail-modal: backlog

--- a/docs/sprint-artifacts/stories/story-P16-3.1.md
+++ b/docs/sprint-artifacts/stories/story-P16-3.1.md
@@ -1,0 +1,86 @@
+# Story P16-3.1: Create Entity Update API Endpoint
+
+Status: done
+
+## Story
+
+As a **backend developer**,
+I want **an endpoint to update entity metadata**,
+So that **users can edit entity properties**.
+
+## Acceptance Criteria
+
+1. **AC1**: Given a valid entity ID, when I call `PUT /api/v1/context/entities/{id}` with `{"name": "Mail Carrier"}`, then the entity name is updated and the response returns the updated entity object
+2. **AC2**: Given partial updates, when I only send `{"is_vip": true}`, then only is_vip is updated, other fields unchanged
+3. **AC3**: Given invalid entity_type value, when I send `{"entity_type": "invalid"}`, then I receive 422 with validation error
+4. **AC4**: Updatable fields: name, entity_type, is_vip, is_blocked, notes
+5. **AC5**: entity_type must be: person, vehicle, unknown
+6. **AC6**: name max length: 255 characters
+7. **AC7**: notes max length: 2000 characters
+8. **AC8**: updated_at timestamp is set automatically
+9. **AC9**: Requires authenticated user (any role can edit)
+
+## Tasks / Subtasks
+
+- [x] Task 1: Verify PUT endpoint exists (AC: 1, 2, 6, 8, 9)
+  - [x] Endpoint already exists at `/api/v1/context/entities/{id}`
+  - [x] Partial updates work (Optional fields)
+  - [x] name max_length=255 already in schema
+  - [x] updated_at auto-updates via onupdate
+  - [x] Requires authentication
+- [x] Task 2: Add entity_type field to EntityUpdateRequest (AC: 3, 4, 5)
+  - [x] Add Literal["person", "vehicle", "unknown"] field
+  - [x] Add validation for entity_type
+- [x] Task 3: Add notes max_length validation (AC: 7)
+  - [x] Add max_length=2000 to notes field
+- [x] Task 4: Update EntityService.update_entity to handle entity_type (AC: 4)
+  - [x] Pass entity_type to service method
+  - [x] Update entity type in database
+- [x] Task 5: Write/update tests (AC: all)
+  - [x] Test entity_type update
+  - [x] Test invalid entity_type returns 422
+  - [x] Test notes max_length validation
+
+## Dev Notes
+
+- PUT endpoint already exists at `backend/app/api/v1/context.py:1138`
+- EntityUpdateRequest schema at `backend/app/api/v1/context.py:536`
+- Currently missing: entity_type field, notes max_length validation
+- EntityService.update_entity method needs entity_type parameter added
+
+### Project Structure Notes
+
+- Backend API: `backend/app/api/v1/context.py`
+- Entity Model: `backend/app/models/recognized_entity.py`
+- Entity Service: `backend/app/services/entity_service.py`
+
+### References
+
+- [Source: docs/epics-phase16.md#Story-P16-3.1]
+- [Source: backend/app/api/v1/context.py#EntityUpdateRequest]
+- [Source: backend/app/models/recognized_entity.py#RecognizedEntity]
+
+## Dev Agent Record
+
+### Context Reference
+
+<!-- Path(s) to story context XML will be added here by context workflow -->
+
+### Agent Model Used
+
+Claude Opus 4.5
+
+### Debug Log References
+
+### Completion Notes List
+
+- Added `entity_type` field with Literal validation to EntityUpdateRequest schema
+- Added `max_length=2000` to notes field in EntityUpdateRequest
+- Updated EntityService.update_entity to handle entity_type parameter
+- Added 6 new tests covering entity_type updates, validation, and notes max_length
+
+### File List
+
+- `backend/app/api/v1/context.py` - EntityUpdateRequest schema and endpoint updates
+- `backend/app/services/entity_service.py` - Added entity_type parameter
+- `backend/tests/test_api/test_entity_api.py` - Added P16-3.1 tests


### PR DESCRIPTION
## Summary

Story P16-3.1: Create Entity Update API Endpoint

Implements entity metadata update functionality for Epic P16-3 (Entity Metadata Editing).

### Changes

- Add `entity_type` field with `Literal["person", "vehicle", "unknown"]` validation to `EntityUpdateRequest`
- Add `max_length=2000` validation for notes field
- Update `EntityService.update_entity` to handle `entity_type` parameter
- Add 6 new tests covering:
  - Entity type updates
  - All valid entity_type values (person, vehicle, unknown)
  - Invalid entity_type returns 422
  - Notes at max length (2000 chars)
  - Notes exceeding max length returns 422
  - Partial updates only modify specified fields

### Acceptance Criteria Completed

- **AC1**: PUT endpoint updates entity and returns updated object
- **AC2**: Partial updates work (only specified fields updated)
- **AC3**: Invalid entity_type returns 422 validation error
- **AC4**: Updatable fields: name, entity_type, is_vip, is_blocked, notes
- **AC5**: entity_type validates to: person, vehicle, unknown
- **AC6**: name max length: 255 characters (pre-existing)
- **AC7**: notes max length: 2000 characters
- **AC8**: updated_at timestamp auto-updates (via SQLAlchemy onupdate)
- **AC9**: Requires authenticated user (pre-existing)

## Test Plan

- [x] All 8 TestUpdateEntityAPI tests pass
- [ ] Manual API testing with curl
- [ ] Verify 422 response for invalid entity_type

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)