### PR TITLE
feat(P16-5): Complete Active Sessions Management epic

### DIFF
--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -1158,12 +1158,15 @@ development_status:
   # Focus: View and manage active login sessions
   # GitHub: #342
   # FRs Covered: FR10-FR15
-  epic-p16-5: backlog
-  p16-5-1-create-session-model-and-tracking: backlog
-  p16-5-2-create-session-api-endpoints: backlog
-  p16-5-3-create-active-sessions-ui: backlog
-  p16-5-4-enforce-maximum-concurrent-sessions: backlog
-  p16-5-5-invalidate-sessions-on-password-change: backlog
+  # Status: COMPLETE 2026-01-02
+  # Notes: P16-5.1 through P16-5.4 were already implemented in Phase 15 (P15-2.2, P15-2.7, P15-2.8)
+  #        P16-5.5 session invalidation on password change added 2026-01-02
+  epic-p16-5: done
+  p16-5-1-create-session-model-and-tracking: done  # Pre-existing: P15-2.2
+  p16-5-2-create-session-api-endpoints: done  # Pre-existing: P15-2.7
+  p16-5-3-create-active-sessions-ui: done  # Pre-existing: P15-2.7
+  p16-5-4-enforce-maximum-concurrent-sessions: done  # Pre-existing: P15-2.8
+  p16-5-5-invalidate-sessions-on-password-change: done  # Added session invalidation on password change
   epic-p16-5-retrospective: optional
 
   # Epic P16-6: Multi-Entity Events


### PR DESCRIPTION
## Summary

This PR completes Epic P16-5: Active Sessions Management (GitHub #342).

Analysis revealed that P16-5.1 through P16-5.4 were already implemented in Phase 15:
- **P16-5.1**: Session Model - from P15-2.2
- **P16-5.2**: Session API Endpoints - from P15-2.7
- **P16-5.3**: Active Sessions UI - from P15-2.7
- **P16-5.4**: Max Concurrent Sessions - from P15-2.8

The only missing piece was **P16-5.5**: Invalidate sessions on password change.

### Changes

- Add session invalidation in password change endpoint (`auth.py`)
- When password is changed, all other sessions are revoked
- Current session remains valid (user stays logged in)
- Response message includes count of revoked sessions (e.g., "Password changed successfully. 2 other sessions signed out.")
- Add comprehensive test for session invalidation behavior
- Update sprint-status.yaml to mark P16-5 epic as done

### FRs Covered

- FR10: Users can view list of active sessions ✅
- FR11: Users can identify current session ✅
- FR12: Users can revoke individual sessions ✅
- FR13: Users can revoke all sessions except current ✅
- FR14: System enforces maximum concurrent sessions ✅
- FR15: Sessions expire after inactivity period ✅

## Test plan

- [x] New test `test_change_password_invalidates_other_sessions` passes
- [x] All 21 auth tests pass
- [x] Frontend lint passes
- [ ] Manual test: Log in from two browsers, change password in one, verify other is logged out

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)