### PR TITLE
fix: harden systemd services to prevent port binding restart loops

### DIFF
--- a/backend/app/utils/startup.py
+++ b/backend/app/utils/startup.py
@@ -1,0 +1,91 @@
+"""Startup utilities for ArgusAI backend.
+
+Includes port availability checks to prevent binding issues during restarts (Issue #383).
+"""
+
+import socket
+import time
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def is_port_available(host: str, port: int) -> bool:
+    """Check if a port is available for binding.
+    
+    Args:
+        host: Host address to check
+        port: Port number to check
+        
+    Returns:
+        True if port is available, False if in use
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(1)
+        result = sock.connect_ex((host, port))
+        return result != 0  # 0 means connection succeeded (port in use)
+
+
+def wait_for_port(
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    timeout: int = 30,
+    interval: float = 1.0
+) -> bool:
+    """Wait for a port to become available.
+    
+    Useful during restarts when the previous process may still be releasing the port.
+    
+    Args:
+        host: Host address to check (default: 127.0.0.1)
+        port: Port number to wait for (default: 8000)
+        timeout: Maximum seconds to wait (default: 30)
+        interval: Seconds between checks (default: 1.0)
+        
+    Returns:
+        True if port became available, False if timeout reached
+        
+    Example:
+        >>> if not wait_for_port(port=8000, timeout=30):
+        ...     raise RuntimeError("Port 8000 still in use after 30s")
+    """
+    start_time = time.time()
+    
+    while time.time() - start_time < timeout:
+        if is_port_available(host, port):
+            elapsed = time.time() - start_time
+            if elapsed > 0.1:  # Only log if we actually waited
+                logger.info(f"Port {port} available after {elapsed:.1f}s")
+            return True
+        
+        logger.debug(f"Port {port} still in use, waiting {interval}s...")
+        time.sleep(interval)
+    
+    logger.warning(f"Port {port} still in use after {timeout}s timeout")
+    return False
+
+
+def check_startup_requirements(host: str = "0.0.0.0", port: int = 8000) -> None:
+    """Run startup checks before binding.
+    
+    Call this before starting uvicorn to ensure clean startup.
+    
+    Args:
+        host: Host to bind to
+        port: Port to bind to
+        
+    Raises:
+        RuntimeError: If startup requirements are not met
+    """
+    # Check port availability (with short wait for restart scenarios)
+    check_host = "127.0.0.1" if host == "0.0.0.0" else host
+    
+    if not is_port_available(check_host, port):
+        logger.info(f"Port {port} in use, waiting for release...")
+        if not wait_for_port(check_host, port, timeout=15):
+            raise RuntimeError(
+                f"Port {port} is still in use after waiting. "
+                f"Check for zombie processes: sudo ss -tlnp | grep {port}"
+            )
+    
+    logger.info(f"Startup checks passed, port {port} available")

--- a/backend/scripts/check_port.py
+++ b/backend/scripts/check_port.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+Port availability check script for ArgusAI.
+
+Run before starting the server to ensure clean startup.
+Can be used as ExecStartPre in systemd.
+
+Usage:
+    python scripts/check_port.py 8000
+    python scripts/check_port.py 8000 --wait 30
+    
+Exit codes:
+    0 - Port is available
+    1 - Port is in use (and --wait timeout reached)
+"""
+
+import argparse
+import socket
+import sys
+import time
+
+
+def is_port_available(host: str, port: int) -> bool:
+    """Check if a port is available for binding."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(1)
+        result = sock.connect_ex((host, port))
+        return result != 0
+
+
+def wait_for_port(host: str, port: int, timeout: int) -> bool:
+    """Wait for a port to become available."""
+    start_time = time.time()
+    
+    while time.time() - start_time < timeout:
+        if is_port_available(host, port):
+            elapsed = time.time() - start_time
+            if elapsed > 0.1:
+                print(f"Port {port} available after {elapsed:.1f}s")
+            return True
+        time.sleep(1)
+    
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check if a port is available for binding"
+    )
+    parser.add_argument(
+        "port",
+        type=int,
+        help="Port number to check"
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host to check (default: 127.0.0.1)"
+    )
+    parser.add_argument(
+        "--wait",
+        type=int,
+        default=0,
+        metavar="SECONDS",
+        help="Wait up to SECONDS for port to become available"
+    )
+    
+    args = parser.parse_args()
+    
+    if args.wait > 0:
+        if not is_port_available(args.host, args.port):
+            print(f"Port {args.port} in use, waiting up to {args.wait}s...")
+            if not wait_for_port(args.host, args.port, args.wait):
+                print(f"ERROR: Port {args.port} still in use after {args.wait}s", file=sys.stderr)
+                print(f"Check: ss -tlnp | grep {args.port}", file=sys.stderr)
+                sys.exit(1)
+    else:
+        if not is_port_available(args.host, args.port):
+            print(f"ERROR: Port {args.port} is in use", file=sys.stderr)
+            print(f"Check: ss -tlnp | grep {args.port}", file=sys.stderr)
+            sys.exit(1)
+    
+    print(f"Port {args.port} is available")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,75 @@
+# ArgusAI systemd Service Files
+
+Hardened systemd service files for running ArgusAI on a standalone Linux server.
+
+## Features (Issue #383)
+
+These service files include hardening to prevent port binding restart loops:
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| `KillMode=mixed` | mixed | Ensures child processes (workers) are killed when main process stops |
+| `TimeoutStopSec=15` | 15s | Gives uvicorn time to gracefully shutdown and release port |
+| `TimeoutStartSec=30` | 30s | Allows time for startup (DB connections, model loading) |
+| `RestartSec=5` | 5s | Delay between restarts to ensure port is released |
+| `--timeout-graceful-shutdown 10` | 10s | Uvicorn graceful shutdown timeout |
+
+## Installation
+
+```bash
+# Copy service files
+sudo cp argusai-backend.service /etc/systemd/system/
+sudo cp argusai-frontend.service /etc/systemd/system/
+
+# Edit paths to match your installation
+sudo nano /etc/systemd/system/argusai-backend.service
+sudo nano /etc/systemd/system/argusai-frontend.service
+
+# Reload systemd
+sudo systemctl daemon-reload
+
+# Enable services to start on boot
+sudo systemctl enable argusai-backend argusai-frontend
+
+# Start services
+sudo systemctl start argusai-backend argusai-frontend
+```
+
+## Troubleshooting
+
+### Check service status
+```bash
+sudo systemctl status argusai-backend
+sudo systemctl status argusai-frontend
+```
+
+### View logs
+```bash
+journalctl -u argusai-backend -f
+journalctl -u argusai-frontend -f
+```
+
+### Check for port conflicts
+```bash
+# Check if port 8000 is in use
+sudo ss -tlnp | grep 8000
+
+# Check if port 3000 is in use  
+sudo ss -tlnp | grep 3000
+```
+
+### Reset restart counter
+If the service has been restarting, reset the counter:
+```bash
+sudo systemctl reset-failed argusai-backend
+```
+
+## Security Hardening
+
+The service files include security sandboxing:
+
+- `NoNewPrivileges=true` - Prevents privilege escalation
+- `PrivateTmp=true` - Isolated /tmp directory
+- `ProtectSystem=strict` - Read-only system directories
+- `ProtectHome=read-only` - Read-only home directories
+- `ReadWritePaths=...` - Explicit write access only where needed

--- a/deploy/systemd/argusai-backend.service
+++ b/deploy/systemd/argusai-backend.service
@@ -1,0 +1,50 @@
+# ArgusAI Backend Service
+# Copy to /etc/systemd/system/argusai-backend.service
+# Then: sudo systemctl daemon-reload && sudo systemctl enable argusai-backend
+
+[Unit]
+Description=ArgusAI - Backend API
+Documentation=https://github.com/project-argusai/ArgusAI
+After=network.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=argusai
+Group=argusai
+WorkingDirectory=/opt/argusai/backend
+Environment="PATH=/opt/argusai/backend/venv/bin"
+# Optional: Pre-start port check (uncomment to enable)
+# ExecStartPre=/opt/argusai/backend/venv/bin/python /opt/argusai/backend/scripts/check_port.py 8000 --wait 15
+ExecStart=/opt/argusai/backend/venv/bin/uvicorn main:app --host 0.0.0.0 --port 8000 --timeout-graceful-shutdown 10
+
+# Restart behavior - Issue #383
+Restart=always
+RestartSec=5
+
+# Process management - prevent port binding issues on restart
+# KillMode=mixed ensures child processes are killed when main process stops
+KillMode=mixed
+# Give uvicorn time to gracefully shutdown and release the port
+TimeoutStopSec=15
+# Allow time for startup (database connections, model loading)
+TimeoutStartSec=30
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=argusai-backend
+
+# Security hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/opt/argusai/backend/data /opt/argusai/backend/logs /var/log/argusai
+
+# Resource limits (adjust as needed)
+# LimitNOFILE=65535
+# MemoryMax=2G
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/argusai-frontend.service
+++ b/deploy/systemd/argusai-frontend.service
@@ -1,0 +1,43 @@
+# ArgusAI Frontend Service
+# Copy to /etc/systemd/system/argusai-frontend.service
+# Then: sudo systemctl daemon-reload && sudo systemctl enable argusai-frontend
+
+[Unit]
+Description=ArgusAI - Frontend
+Documentation=https://github.com/project-argusai/ArgusAI
+After=network.target argusai-backend.service
+Wants=argusai-backend.service
+
+[Service]
+Type=simple
+User=argusai
+Group=argusai
+WorkingDirectory=/opt/argusai/frontend
+Environment="NODE_ENV=production"
+# Uncomment for HTTPS:
+# Environment="SSL_CERT_FILE=/opt/argusai/certs/cert.pem"
+# Environment="SSL_KEY_FILE=/opt/argusai/certs/key.pem"
+ExecStart=/usr/bin/npm run start
+
+# Restart behavior - Issue #383
+Restart=always
+RestartSec=5
+
+# Process management - prevent port binding issues on restart
+KillMode=mixed
+TimeoutStopSec=15
+TimeoutStartSec=30
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=argusai-frontend
+
+# Security hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+
+[Install]
+WantedBy=multi-user.target

--- a/install.sh
+++ b/install.sh
@@ -1188,9 +1188,14 @@ User=$USER
 Group=$USER
 WorkingDirectory=$BACKEND_DIR
 Environment="PATH=$BACKEND_DIR/venv/bin"
-ExecStart=$BACKEND_DIR/venv/bin/uvicorn main:app --host 0.0.0.0 --port 8000
+ExecStart=$BACKEND_DIR/venv/bin/uvicorn main:app --host 0.0.0.0 --port 8000 --timeout-graceful-shutdown 10
 Restart=always
-RestartSec=10
+RestartSec=5
+
+# Process management - prevent port binding issues on restart (Issue #383)
+KillMode=mixed
+TimeoutStopSec=15
+TimeoutStartSec=30
 
 # Logging
 StandardOutput=journal
@@ -1200,6 +1205,9 @@ SyslogIdentifier=argusai-backend
 # Security hardening
 NoNewPrivileges=true
 PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=$BACKEND_DIR/data $BACKEND_DIR/logs
 
 [Install]
 WantedBy=multi-user.target
@@ -1233,7 +1241,12 @@ Environment="NODE_ENV=production"
 $ssl_env_section
 ExecStart=/usr/bin/npm run $frontend_start_cmd
 Restart=always
-RestartSec=10
+RestartSec=5
+
+# Process management - prevent port binding issues on restart (Issue #383)
+KillMode=mixed
+TimeoutStopSec=15
+TimeoutStartSec=30
 
 # Logging
 StandardOutput=journal
@@ -1243,6 +1256,8 @@ SyslogIdentifier=argusai-frontend
 # Security hardening
 NoNewPrivileges=true
 PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Fixes #383 — prevents the restart loop issue where the backend service accumulated 11,907+ restarts due to port binding conflicts.

## Changes

### systemd Service Hardening (install.sh)

| Setting | Before | After | Purpose |
|---------|--------|-------|---------|
| `KillMode` | (default) | `mixed` | Ensures child processes (uvicorn workers) are killed on stop |
| `TimeoutStopSec` | (default) | `15` | Gives uvicorn time to gracefully shutdown and release port |
| `TimeoutStartSec` | (default) | `30` | Allows time for startup (DB connections, model loading) |
| `RestartSec` | `10` | `5` | Delay between restarts (safe with proper stop timeout) |
| `ProtectSystem` | - | `strict` | Security: read-only system directories |
| `ProtectHome` | - | `read-only` | Security: read-only home directories |

### uvicorn Changes

Added `--timeout-graceful-shutdown 10` to allow in-flight requests to complete before shutdown.

### New Files

- `deploy/systemd/` — Standalone service files with documentation
- `backend/scripts/check_port.py` — Optional pre-start port availability check
- `backend/app/utils/startup.py` — Port check utilities for programmatic use

## How It Works

1. When systemd sends SIGTERM, `KillMode=mixed` ensures all child processes receive the signal
2. `TimeoutStopSec=15` gives uvicorn 15 seconds to finish graceful shutdown
3. uvicorn's `--timeout-graceful-shutdown 10` completes in-flight requests
4. Port is released before the 5-second `RestartSec` delay
5. Next start attempt finds the port available

## Testing

```bash
# Simulate restart loop
for i in {1..5}; do
  sudo systemctl restart argusai-backend
  sleep 2
  sudo systemctl status argusai-backend --no-pager | head -5
done
```

## Acceptance Criteria

- [x] Service restarts cleanly without port binding errors
- [x] No zombie processes left after service stop
- [x] Restart counter stays low during normal operation