### PR TITLE
fix: improve Protect controller reconnect error handling

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -400,6 +400,9 @@ async def lifespan(app: FastAPI):
     # Connect to Protect controllers on startup (Story P2-1.4, AC1)
     from app.models.protect_controller import ProtectController
     protect_service = get_protect_service()
+    
+    # Reset stale connection states from previous crashes (Issue #382)
+    await protect_service.reset_stale_connection_states()
 
     db = next(get_db())
     try:


### PR DESCRIPTION
## Summary

Fixes #382 — improves Protect controller reconnect error handling and clears stale connection states on startup.

## Root Cause

The original issue showed `Reconnect failed: NvrError` in the API response. Investigation revealed this was caused by:

1. Service restart loop (fixed in #383) causing repeated crashes
2. Crash leaving stale `is_connected=True` in database
3. Reconnect errors only storing exception type, not full details
4. No mechanism to clear stale state on restart

## Changes

### 1. Enhanced Error Messages

**Before:**
```
last_error: "Reconnect failed: NvrError"
```

**After:**
```
last_error: "Reconnect failed: NvrError: Connection refused by controller"
```

### 2. Stale State Reset on Startup

New `reset_stale_connection_states()` method:
- Runs before connecting to controllers on startup
- Resets any controllers marked as `is_connected=True` to `False`
- Preserves old errors with `[Stale after restart]` prefix for debugging

### 3. Better Logging

Added `error_message` to reconnect failure log events for easier debugging.

## Testing

The changes are minimal and focused:
- Error message formatting change in reconnect logic
- New async method that queries/updates DB
- Single line addition to startup sequence

CI will validate no regressions.

## Related

- #383 (systemd hardening) fixed the root cause (restart loop)
- This PR improves error visibility and cleans up stale state