### PR TITLE
fix: allow private IPs for LAN webhooks

### DIFF
--- a/backend/app/services/alert_engine.py
+++ b/backend/app/services/alert_engine.py
@@ -1122,10 +1122,12 @@ class AlertEngine:
             return False
 
         # Use WebhookService for execution with security features
+        # allow_private_ips=True enables LAN webhooks (e.g., OpenClaw, Home Assistant)
         webhook_service = WebhookService(
             db=self.db,
             http_client=self.http_client,
-            allow_http=True  # Allow http for local development
+            allow_http=True,  # Allow http for local development
+            allow_private_ips=True  # Allow LAN/private IPs for internal integrations
         )
 
         result = await webhook_service.execute_rule_webhook(event, rule)


### PR DESCRIPTION
## Problem

Webhooks to LAN addresses (e.g., `https://10.0.1.32:18789/hooks/argusai`) were being silently blocked by SSRF protection in `WebhookService`.

The `PRIVATE_IP_RANGES` include `10.0.0.0/8`, which blocks all internal/LAN webhooks from firing.

This prevented OpenClaw integration from receiving real-time camera events.

## Solution

Added `allow_private_ips` flag to `WebhookService`:

- When `True`, skips the private IP check (still blocks localhost for safety)
- Alert engine now passes `allow_private_ips=True` by default
- Enables webhooks to internal services like OpenClaw, Home Assistant, etc.

## Testing

- Added test case for `allow_private_ips=True` behavior
- Verified existing SSRF tests still pass

## Related

Enables OpenClaw ↔ ArgusAI real-time event integration.