### PR TITLE
fix(ai): refresh Claude model registry — add Haiku 4.5 / Sonnet 4.6 / Opus 4.7

### DIFF
--- a/backend/app/api/v1/system.py
+++ b/backend/app/api/v1/system.py
@@ -732,7 +732,7 @@ async def _test_anthropic_key(api_key: str) -> tuple[bool, str]:
         # Make a minimal message request to test the key
         # Using count_tokens is not available, so we make a small completion
         response = client.messages.create(
-            model="claude-3-haiku-20240307",
+            model="claude-haiku-4-5-20251001",
             max_tokens=1,
             messages=[{"role": "user", "content": "test"}]
         )

--- a/backend/app/schemas/system.py
+++ b/backend/app/schemas/system.py
@@ -158,15 +158,19 @@ class SystemSettings(BaseModel):
     primary_api_key: str = Field(default="")  # Encrypted in storage
     fallback_model: Optional[Literal["gpt-4o-mini", "claude-3-haiku", "gemini-flash"]] = Field(default=None)
 
-    # Claude Model Selection
+    # Claude Model Selection. Newest first; legacy IDs accepted for
+    # backwards-compatibility with stored settings.
     claude_model: Literal[
-        "claude-3-haiku-20240307",
-        "claude-3-5-haiku-20241022",
-        "claude-3-5-sonnet-20241022",
+        "claude-haiku-4-5-20251001",
+        "claude-sonnet-4-6",
+        "claude-opus-4-7",
         "claude-sonnet-4-20250514",
-        "claude-opus-4-20250514"
+        "claude-opus-4-20250514",
+        "claude-3-5-sonnet-20241022",
+        "claude-3-5-haiku-20241022",
+        "claude-3-haiku-20240307",
     ] = Field(
-        default="claude-3-haiku-20240307",
+        default="claude-haiku-4-5-20251001",
         description="Anthropic Claude model to use. Haiku is fastest/cheapest, Opus is most capable."
     )
 
@@ -276,13 +280,16 @@ class SystemSettingsUpdate(BaseModel):
     primary_api_key: Optional[str] = None
     fallback_model: Optional[Literal["gpt-4o-mini", "claude-3-haiku", "gemini-flash"]] = None
 
-    # Claude Model Selection
+    # Claude Model Selection. Must match the union in SystemSettings (above).
     claude_model: Optional[Literal[
-        "claude-3-haiku-20240307",
-        "claude-3-5-haiku-20241022",
-        "claude-3-5-sonnet-20241022",
+        "claude-haiku-4-5-20251001",
+        "claude-sonnet-4-6",
+        "claude-opus-4-7",
         "claude-sonnet-4-20250514",
-        "claude-opus-4-20250514"
+        "claude-opus-4-20250514",
+        "claude-3-5-sonnet-20241022",
+        "claude-3-5-haiku-20241022",
+        "claude-3-haiku-20240307",
     ]] = Field(None, description="Anthropic Claude model to use")
 
     description_prompt: Optional[str] = None

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -1256,16 +1256,23 @@ class OpenAIProvider(AIProviderBase):
 class ClaudeProvider(AIProviderBase):
     """Anthropic Claude vision provider with model selection"""
 
-    # Pricing per 1K tokens for each model (as of Jan 2025)
+    # Pricing per 1K tokens for each model. Newest first; legacy IDs kept
+    # so historical events priced under those models still report correct cost.
     MODEL_PRICING = {
-        "claude-3-haiku-20240307": {"input": 0.00025, "output": 0.00125},
-        "claude-3-5-haiku-20241022": {"input": 0.001, "output": 0.005},
-        "claude-3-5-sonnet-20241022": {"input": 0.003, "output": 0.015},
+        # Claude 4.x family (current as of 2026)
+        "claude-haiku-4-5-20251001": {"input": 0.001, "output": 0.005},
+        "claude-sonnet-4-6": {"input": 0.003, "output": 0.015},
+        "claude-opus-4-7": {"input": 0.015, "output": 0.075},
+        # Older 4.0 releases
         "claude-sonnet-4-20250514": {"input": 0.003, "output": 0.015},
         "claude-opus-4-20250514": {"input": 0.015, "output": 0.075},
+        # Legacy 3.x family
+        "claude-3-5-sonnet-20241022": {"input": 0.003, "output": 0.015},
+        "claude-3-5-haiku-20241022": {"input": 0.001, "output": 0.005},
+        "claude-3-haiku-20240307": {"input": 0.00025, "output": 0.00125},
     }
 
-    DEFAULT_MODEL = "claude-3-haiku-20240307"
+    DEFAULT_MODEL = "claude-haiku-4-5-20251001"
 
     def __init__(self, api_key: str, model: str = None):
         super().__init__(api_key)

--- a/backend/app/services/litellm_provider.py
+++ b/backend/app/services/litellm_provider.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 MODEL_MAPPINGS = {
     "openai": "openai/gpt-4o-mini",
     "grok": "xai/grok-2-vision-1212",
-    "claude": "anthropic/claude-3-haiku-20240307",
+    "claude": "anthropic/claude-haiku-4-5-20251001",
     "gemini": "gemini/gemini-2.5-flash",
 }
 

--- a/backend/app/services/summary_service.py
+++ b/backend/app/services/summary_service.py
@@ -637,7 +637,7 @@ Timeline:
         client = anthropic.AsyncAnthropic(api_key=api_key)
 
         response = await client.messages.create(
-            model="claude-3-haiku-20240307",
+            model="claude-haiku-4-5-20251001",
             max_tokens=300,
             system=system_prompt,
             messages=[

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -704,7 +704,7 @@ export default function SettingsPage() {
                 <AIProviders
                   configuredProviders={configuredProviders}
                   providerOrder={providerOrder}
-                  claudeModel={form.watch('claude_model') || 'claude-3-haiku-20240307'}
+                  claudeModel={form.watch('claude_model') || 'claude-haiku-4-5-20251001'}
                   onProviderConfigured={(provider) => {
                     setConfiguredProviders((prev) => new Set([...prev, provider]));
                   }}

--- a/frontend/components/settings/AIProviders.tsx
+++ b/frontend/components/settings/AIProviders.tsx
@@ -99,8 +99,8 @@ const PROVIDER_DATA: Record<
   },
   anthropic: {
     name: 'Anthropic Claude',
-    description: 'Claude 3 Haiku - Efficient and accurate',
-    model: 'claude-3-haiku',
+    description: 'Claude Haiku 4.5 - Latest fast vision model',
+    model: 'claude-haiku-4-5-20251001',
     icon: <Brain className="h-5 w-5" />,
   },
   google: {
@@ -219,7 +219,7 @@ interface AIProvidersProps {
 export function AIProviders({
   configuredProviders,
   providerOrder: initialOrder,
-  claudeModel = 'claude-3-haiku-20240307',
+  claudeModel = 'claude-haiku-4-5-20251001',
   onProviderConfigured,
   onProviderRemoved,
   onProviderOrderChanged,

--- a/frontend/lib/settings-validation.ts
+++ b/frontend/lib/settings-validation.ts
@@ -32,13 +32,17 @@ export const aiModelsSettingsSchema = z.object({
     .enum(['gpt-4o-mini', 'claude-3-haiku', 'gemini-flash'])
     .nullable()
     .optional(),
-  // Claude Model Selection
+  // Claude Model Selection. Must match the ClaudeModel union in
+  // `types/settings.ts` and the Literal in `backend/app/schemas/system.py`.
   claude_model: z.enum([
-    'claude-3-haiku-20240307',
-    'claude-3-5-haiku-20241022',
-    'claude-3-5-sonnet-20241022',
+    'claude-haiku-4-5-20251001',
+    'claude-sonnet-4-6',
+    'claude-opus-4-7',
     'claude-sonnet-4-20250514',
     'claude-opus-4-20250514',
+    'claude-3-5-sonnet-20241022',
+    'claude-3-5-haiku-20241022',
+    'claude-3-haiku-20240307',
   ]).optional(),
   description_prompt: z.string().min(10, 'Prompt must be at least 10 characters'),
   // Story P9-3.5: Summary Prompt Customization

--- a/frontend/types/settings.ts
+++ b/frontend/types/settings.ts
@@ -67,23 +67,30 @@ export interface SystemSettings {
   frame_extraction_offset_ms?: number;  // Milliseconds to skip from clip start (0-10000, default: 2000)
 
   // Claude Model Selection
-  claude_model?: ClaudeModel;  // Selected Claude model (default: claude-3-haiku-20240307)
+  claude_model?: ClaudeModel;  // Selected Claude model (default: claude-haiku-4-5-20251001)
 }
 
-// Claude model options
+// Claude model options. Newest first; legacy IDs kept at the bottom for
+// backwards compatibility with stored settings.
 export type ClaudeModel =
-  | 'claude-3-haiku-20240307'
-  | 'claude-3-5-haiku-20241022'
-  | 'claude-3-5-sonnet-20241022'
+  | 'claude-haiku-4-5-20251001'
+  | 'claude-sonnet-4-6'
+  | 'claude-opus-4-7'
   | 'claude-sonnet-4-20250514'
-  | 'claude-opus-4-20250514';
+  | 'claude-opus-4-20250514'
+  | 'claude-3-5-sonnet-20241022'
+  | 'claude-3-5-haiku-20241022'
+  | 'claude-3-haiku-20240307';
 
 export const CLAUDE_MODELS: { value: ClaudeModel; label: string; description: string }[] = [
-  { value: 'claude-3-haiku-20240307', label: 'Claude 3 Haiku', description: 'Fastest, lowest cost ($0.25/$1.25 per 1M tokens)' },
-  { value: 'claude-3-5-haiku-20241022', label: 'Claude 3.5 Haiku', description: 'Faster, low cost ($1/$5 per 1M tokens)' },
-  { value: 'claude-3-5-sonnet-20241022', label: 'Claude 3.5 Sonnet', description: 'Balanced ($3/$15 per 1M tokens)' },
-  { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4', description: 'Advanced ($3/$15 per 1M tokens)' },
-  { value: 'claude-opus-4-20250514', label: 'Claude Opus 4', description: 'Most capable ($15/$75 per 1M tokens)' },
+  { value: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5', description: 'Newest fast vision model — best price/quality for short scene descriptions ($1/$5 per 1M tokens)' },
+  { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', description: 'Balanced quality and cost ($3/$15 per 1M tokens)' },
+  { value: 'claude-opus-4-7', label: 'Claude Opus 4.7', description: 'Most capable — reserve for hard cases ($15/$75 per 1M tokens)' },
+  { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4 (legacy)', description: 'Older Sonnet 4 release ($3/$15 per 1M tokens)' },
+  { value: 'claude-opus-4-20250514', label: 'Claude Opus 4 (legacy)', description: 'Older Opus 4 release ($15/$75 per 1M tokens)' },
+  { value: 'claude-3-5-sonnet-20241022', label: 'Claude 3.5 Sonnet (legacy)', description: 'Legacy ($3/$15 per 1M tokens)' },
+  { value: 'claude-3-5-haiku-20241022', label: 'Claude 3.5 Haiku (legacy)', description: 'Legacy ($1/$5 per 1M tokens)' },
+  { value: 'claude-3-haiku-20240307', label: 'Claude 3 Haiku (legacy)', description: 'Legacy fast/cheap ($0.25/$1.25 per 1M tokens)' },
 ];
 
 export interface StorageStats {


### PR DESCRIPTION
Adds current-gen Claude model IDs (Haiku 4.5, Sonnet 4.6, Opus 4.7) to every model enumeration in the codebase and bumps the default for fresh installs to Haiku 4.5. Legacy IDs are preserved in every union/enum/pricing table so stored selections keep working.

**Why:** The settings UI was offering Claude 3 Haiku as the newest Anthropic option; operators picking 'Haiku' got routed to a 2-generation-behind model. Hit live on 2026-05-11.

**Defaults bumped to** `claude-haiku-4-5-20251001` (same price tier as 3.5 Haiku, current-gen quality).

**Files (9 total):**
- Backend: `schemas/system.py`, `services/litellm_provider.py`, `services/ai_service.py` (pricing + DEFAULT_MODEL), `services/summary_service.py`, `api/v1/system.py` (`_test_anthropic_key`)
- Frontend: `types/settings.ts` (`CLAUDE_MODELS` array + `ClaudeModel` union), `lib/settings-validation.ts` (zod enum), `components/settings/AIProviders.tsx` (`PROVIDER_DATA` + component prop default), `app/settings/page.tsx` (form watch fallback)

**Back-compat:** Every legacy ID (`claude-3-haiku-20240307`, `claude-3-5-*`, `claude-{sonnet,opus}-4-20250514`) preserved everywhere it appeared; migration is purely additive. Tests using legacy IDs continue to pass without changes.

**Out of scope:**
- Other providers (`gpt-4o-mini`, `grok-2-vision-1212`, `gemini-2.5-flash`) — leaving for a follow-up.
- The `primary_model` high-level alias enum.
- Gemini producing 2–8 word descriptions on the live instance — separate root cause (key/quota at the provider level).

**Manual verification after deploy:** Settings → AI Providers → Anthropic → confirm dropdown shows Haiku 4.5 / Sonnet 4.6 / Opus 4.7 at top; switch to 4.5; trigger an event; confirm descriptions are no longer 'too short'.