### PR TITLE
fix(ai): refresh Grok model ID — grok-2-vision-1212 → grok-4

### DIFF
--- a/backend/app/api/v1/ai.py
+++ b/backend/app/api/v1/ai.py
@@ -366,7 +366,7 @@ async def _call_provider_for_refinement(provider, provider_enum, meta_prompt: st
     elif provider_enum == AIProvider.GROK:
         # Grok uses OpenAI-compatible API
         response = await provider.client.chat.completions.create(
-            model="grok-2-vision-1212",
+            model="grok-4",
             messages=[
                 {"role": "system", "content": "You are an expert at writing effective AI prompts for image description tasks."},
                 {"role": "user", "content": meta_prompt}

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -2282,9 +2282,12 @@ class GrokProvider(AIProviderBase):
             api_key=api_key,
             base_url="https://api.x.ai/v1"
         )
-        self.model = "grok-2-vision-1212"
-        self.cost_per_1k_input_tokens = 0.00010  # Approximate (similar to GPT-4o mini)
-        self.cost_per_1k_output_tokens = 0.00040
+        # `grok-4` is xAI's current flagship and is multimodal (text + vision).
+        # The previous `grok-2-vision-1212` (Dec 2024 vision-only release) is
+        # retired in xAI's current pricing/availability tiers.
+        self.model = "grok-4"
+        self.cost_per_1k_input_tokens = 0.003   # $3 per 1M input tokens
+        self.cost_per_1k_output_tokens = 0.015  # $15 per 1M output tokens
 
     async def generate_multi_image_description(
         self,

--- a/backend/app/services/litellm_provider.py
+++ b/backend/app/services/litellm_provider.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 # Format: provider/model-name
 MODEL_MAPPINGS = {
     "openai": "openai/gpt-4o-mini",
-    "grok": "xai/grok-2-vision-1212",
+    "grok": "xai/grok-4",
     "claude": "anthropic/claude-haiku-4-5-20251001",
     "gemini": "gemini/gemini-2.5-flash",
 }

--- a/backend/app/services/summary_service.py
+++ b/backend/app/services/summary_service.py
@@ -596,7 +596,7 @@ Timeline:
         )
 
         response = await client.chat.completions.create(
-            model="grok-2-vision-1212",
+            model="grok-4",
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt}

--- a/backend/tests/test_integration/test_grok_provider.py
+++ b/backend/tests/test_integration/test_grok_provider.py
@@ -112,8 +112,8 @@ class TestGrokProviderConfiguration:
         assert grok_provider.client.base_url.host == "api.x.ai"
 
     def test_grok_uses_correct_model(self, grok_provider):
-        """Test Grok uses grok-2-vision-1212 model"""
-        assert grok_provider.model == "grok-2-vision-1212"
+        """Test Grok uses the current grok-4 multimodal model."""
+        assert grok_provider.model == "grok-4"
 
     def test_grok_provider_instantiation(self):
         """Test Grok provider can be instantiated"""

--- a/backend/tests/test_services/test_ai_service.py
+++ b/backend/tests/test_services/test_ai_service.py
@@ -306,9 +306,9 @@ class TestGrokProvider:
         assert "v1" in str(provider.client.base_url)
 
     def test_grok_uses_correct_model(self):
-        """Test that GrokProvider uses grok-2-vision-1212 model (AC2)"""
+        """Test that GrokProvider uses the current grok-4 multimodal model (AC2)."""
         provider = GrokProvider("xai-test-key")
-        assert provider.model == "grok-2-vision-1212"
+        assert provider.model == "grok-4"
 
     @pytest.mark.parametrize("description,expected_objects", [
         ("A person is standing at the door", ['person']),

--- a/backend/tests/test_services/test_litellm_provider.py
+++ b/backend/tests/test_services/test_litellm_provider.py
@@ -331,7 +331,7 @@ class TestLiteLLMProviderDetection:
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = "Test"
-        mock_response.model = "xai/grok-2-vision"
+        mock_response.model = "xai/grok-4"
         mock_response.usage = MagicMock()
         mock_response.usage.total_tokens = 50
 

--- a/frontend/components/settings/AIProviders.tsx
+++ b/frontend/components/settings/AIProviders.tsx
@@ -93,8 +93,8 @@ const PROVIDER_DATA: Record<
   },
   grok: {
     name: 'xAI Grok',
-    description: "Grok Vision - xAI's vision-capable model",
-    model: 'grok-2-vision-1212',
+    description: "Grok 4 - xAI's flagship multimodal (text + vision) model",
+    model: 'grok-4',
     icon: <Sparkles className="h-5 w-5" />,
   },
   anthropic: {


### PR DESCRIPTION
Follow-up to #403 (Claude registry refresh). Bumps the hardcoded Grok model from `grok-2-vision-1212` (Dec 2024 vision-only) to `grok-4` (current multimodal flagship).

This matches Brent's existing hand-patch on the live argusai server (preserved as a stash on 2026-05-11 during the deploy cleanup) and the convention used in `argus-notes/multi-model-dev/routing.yaml`.

## Changes (8 files)

**Backend**
- `app/services/litellm_provider.py` — `MODEL_MAPPINGS["grok"]`
- `app/services/ai_service.py` — `GrokProvider.model` + pricing bumped to current grok-4 rates ($3 / $15 per 1M tokens)
- `app/services/summary_service.py` — hardcoded Grok text-completion model
- `app/api/v1/ai.py` — Grok prompt-improvement completion call

**Tests** (assertions updated, all stay valid)
- `tests/test_integration/test_grok_provider.py`
- `tests/test_services/test_ai_service.py`
- `tests/test_services/test_litellm_provider.py`

**Frontend**
- `components/settings/AIProviders.tsx` — `PROVIDER_DATA.grok` display + model

## Pricing note

grok-2-vision-1212 was approximated at the GPT-4o-mini rate (~$0.10 / $0.40 per 1M tokens). grok-4 is $3 / $15 per 1M — closer to Claude Sonnet 4.6 / GPT-4o. Per-event cost rises noticeably; the `ai_daily_cost_cap` / `ai_monthly_cost_cap` settings are the existing guardrails.

## Intentionally out of scope

- **OpenAI** — `gpt-4o-mini` is an alias that always points to the current OpenAI cost-effective mini. No change needed.
- **Gemini** — `gemini-2.5-flash` is still current. The bad Gemini outputs on production (events with `vague_reason: "Description too short"`) are a key/quota issue at the provider level, not a model-ID problem.
- **Per-provider model dropdowns** (mirroring Claude's picker for OpenAI/Grok/Gemini too) — a more complete UX but a bigger change. Worth filing a follow-up issue if you want it.

## Test plan

- [x] No production code paths reference `grok-2-vision-1212` anymore (grep confirmed; only the explanatory comment remains).
- [x] Existing Grok provider tests updated to assert `grok-4`.
- [ ] CI: backend pytest, frontend lint/build.
- [ ] **Manual on web01 deploy:** trigger an event with the Grok provider in the active fallback chain, confirm description is generated.
