### PR TITLE
security(deps): bump cryptography 46.0.5 → 46.0.7

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,7 +22,7 @@ opencv-python-headless>=4.12.0  # Headless version for servers (no GUI/libGL dep
 av>=12.0.0  # PyAV for secure RTSP (rtsps://) streams
 
 # Security and Encryption
-cryptography==46.0.5
+cryptography==46.0.7
 python-jose[cryptography]==3.5.0
 bcrypt>=4.2.0
 slowapi>=0.1.9


### PR DESCRIPTION
Closes 2 of 3 pip alerts tracked in #406.

| CVE | Severity | Fix |
|---|---|---|
| CVE-2026-39892 | medium | 46.0.7 — buffer overflow with non-contiguous buffers |
| CVE-2026-34073 | low | 46.0.6 — incomplete DNS name constraint enforcement (subsumed by 46.0.7) |

Supersedes the stale Dependabot PR #402 (which only bumped to 46.0.6).

The remaining pip alert — `pytest` 7.4.3 → 9.0.3 — is a major-version migration with real risk of fixture churn. Deferred to a separate PR.

## Test plan
- [x] No other code in the repo pins to specific cryptography APIs that changed between 46.0.5 and 46.0.7 (patch-version-only bump in the 46.x line)
- [ ] CI: backend pytest
