### PR TITLE
fix(tests): update stale assertions in test_store_event_without_ai

### DIFF
--- a/backend/tests/test_services/test_fallback_chain.py
+++ b/backend/tests/test_services/test_fallback_chain.py
@@ -533,8 +533,11 @@ class TestStoreEventWithoutAI:
             assert "video_native:" in call_kwargs['fallback_reason']
             assert "multi_frame:" in call_kwargs['fallback_reason']
 
-            mock_db.add.assert_called_once()
-            mock_db.commit.assert_called_once()
+            # P4-3.3/P4-3.4: function also persists EventEmbedding / RecognizedEntity / EntityEvent
+            # via the embedding+entity pipeline, so add/commit fire more than once. AC3 only requires
+            # the Event itself to be added and committed.
+            mock_db.add.assert_any_call(mock_event)
+            assert mock_db.commit.called
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes the stale backend test that's been failing on every PR's CI (most recently surfaced on #409 and the open Dependabot PRs #410, #411).

Production code in \`_store_event_without_ai\` (\`backend/app/services/protect_event_handler.py:2797\`) was extended for P4-3.3/P4-3.4 (entity matching even for AI-failed events) and now persists 4 ORM objects in the same flow:

1. \`Event\` (line 2854)
2. \`EventEmbedding\` (via \`embedding_service.store_embedding\`, line 2871)
3. \`RecognizedEntity\` + \`EntityEvent\` (via \`entity_service.match_or_create_entity\`, line 2882)

Test still asserted \`mock_db.add.assert_called_once()\` from the pre-P4-3.3 era.

## Fix

Switch to:

\`\`\`python
mock_db.add.assert_any_call(mock_event)
assert mock_db.commit.called
\`\`\`

This keeps the test focused on AC3 (Event was created with correct description) without breaking when the embedding/entity pipeline adds more side-records. The Event-creation behavior is what the test name promises; everything else is incidental.

## Closes

- #415

## Test plan

- [ ] CI passes (the whole point — this PR exists to make CI green again)
- [ ] \`tests/test_services/test_fallback_chain.py::TestStoreEventWithoutAI::test_store_event_without_ai_sets_description\` passes
- [ ] No other tests in \`test_fallback_chain.py\` regress