### PR TITLE
fix(camera): add missing Optional import (startup crash hotfix)

### DIFF
--- a/backend/app/services/camera_service.py
+++ b/backend/app/services/camera_service.py
@@ -12,7 +12,7 @@ import threading
 import time
 import logging
 import asyncio
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from datetime import datetime, timezone
 import numpy as np
 from app.core.decorators import singleton


### PR DESCRIPTION
## Incident hotfix

`backend/app/services/camera_service.py` imported only `from typing import Dict, Any` but uses `Optional` in 7 annotations (e.g. `get_camera_status`, line ~166). At import time this raises:

```
NameError: name 'Optional' is not defined
```

…which crashes the backend on startup (systemd restart loop / k8s CrashLoopBackOff).

**Why it was latent:** production ran an older long-lived process that predated the offending commit. The bug only surfaced when the backend was restarted during a deploy.

## Fix
`from typing import Dict, Any` → `from typing import Dict, Any, Optional`.

## Verification
- `import app.services.camera_service` — OK.
- `import main` (the uvicorn entrypoint) — **full FastAPI app loads cleanly**.
- Scanned the rest of `app/` for the same class of missing-typing-import bug; no other real occurrences (two AST false-positives confirmed importing fine).

Hotfixing forward (rollback wouldn't help — the bug predates the currently-deployed commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)