### PR TITLE
fix(services): add missing typing imports (startup crash hotfix #2)

### DIFF
--- a/backend/app/services/ai_processing_worker.py
+++ b/backend/app/services/ai_processing_worker.py
@@ -10,7 +10,7 @@ the AI pipeline (_process_event).
 import asyncio
 import logging
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Awaitable, Callable
 
 if TYPE_CHECKING:
     from app.services.event_processor import EventProcessor, ProcessingEvent

--- a/backend/app/services/event_processor.py
+++ b/backend/app/services/event_processor.py
@@ -33,7 +33,7 @@ from app.core.metrics import ai_concurrent_in_flight
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set
 from contextlib import asynccontextmanager
 import os
 import json


### PR DESCRIPTION
## Incident hotfix (continuation of #479)

After #479 fixed `Optional` in `camera_service.py`, the backend still crash-looped on the **same bug class** in two more modules:

- `ai_processing_worker.py:41` — `NameError: name 'Callable' is not defined` (also used `Awaitable`); imported only `TYPE_CHECKING`.
- `event_processor.py` — uses `Any`; imported only `Dict, List, Optional, Set`.

## Why local CI/dev missed it
Local dev runs **Python 3.14**, where PEP 649 **defers annotation evaluation** — a missing typing name used only in an annotation does not resolve at import, so `import` succeeds. **Production runs Python 3.12**, which evaluates annotations at class-definition time and raises `NameError`. Runtime import tests on 3.14 cannot catch this; a **static AST scan** can.

## Fix + completeness
Added the missing names to each import. Ran a version-independent AST scan over all of `backend/app/` (using `typing.__all__`, with bound-name awareness): **0 remaining** missing-typing-import occurrences after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)