### PR TITLE
fix(prod): protect/camera startup regressions + CI/deploy guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,48 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  startup-smoke:
+    # Guards the two failure modes that took prod down on 2026-06-28:
+    #  1. Import-time NameError from missing `typing` imports — masked locally
+    #     on Python 3.14 (PEP 649 defers annotation eval) but fatal on prod's
+    #     Python 3.12. We import the real uvicorn entrypoint on 3.12 to catch it.
+    #  2. Migrations that don't apply cleanly — we run `alembic upgrade head`
+    #     against a fresh DB. (Does not catch "prod was never migrated"; the
+    #     deploy migration-gate in deploy.yml / scripts/deploy-baremetal.sh does.)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12 (matches production)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Import app entrypoint (fail on import-time NameError)
+        run: python -c "import main; print('main import OK', type(main.app).__name__)"
+        env:
+          DATABASE_URL: sqlite:///./smoke.db
+          ENCRYPTION_KEY: ${{ secrets.TEST_ENCRYPTION_KEY || 'YhLHon9m3QOhb394b-Qa761Vgj9ij3oLlT-moS2oRcg=' }}
+          JWT_SECRET_KEY: ci-smoke-test-secret-not-for-production
+          PYTHONPATH: .
+
+      - name: Verify migrations apply cleanly to head
+        run: alembic upgrade head
+        env:
+          DATABASE_URL: sqlite:///./smoke_migrate.db
+          ENCRYPTION_KEY: ${{ secrets.TEST_ENCRYPTION_KEY || 'YhLHon9m3QOhb394b-Qa761Vgj9ij3oLlT-moS2oRcg=' }}
+          JWT_SECRET_KEY: ci-smoke-test-secret-not-for-production
+          PYTHONPATH: .
+
   frontend-tests:
     runs-on: ubuntu-latest
     defaults:

--- a/backend/app/services/camera_task_manager.py
+++ b/backend/app/services/camera_task_manager.py
@@ -104,7 +104,7 @@ class CameraTaskManager:
 
         Shared between per-camera motion tasks and the background health monitor.
         """
-        stats = self.motion_task_stats.setdefault(camera.id, {})
+        stats = self._motion_task_stats.setdefault(camera.id, {})
         recovery_attempts = stats.get("recovery_attempts", 0) + 1
         stats["recovery_attempts"] = recovery_attempts
 

--- a/backend/app/services/protect_event_handler.py
+++ b/backend/app/services/protect_event_handler.py
@@ -183,7 +183,16 @@ class ProtectEventHandler:
         # Story P3-5.3: Track last audio transcription for passing to event storage
         self._last_audio_transcription: Optional[str] = None
 
-    # _try_ocr_extraction removed — can be moved to a shared OCR service later if needed (Phase 4)
+    def _try_ocr_extraction(self, frame, db) -> Optional[str]:
+        """Extract overlay text from a frame via OCR, if enabled in settings.
+
+        Returns the extracted text, or None when OCR is disabled or unavailable.
+
+        NOTE: This method's `def` line was accidentally dropped in a refactor,
+        leaving the body orphaned inside __init__ and crashing handler
+        construction with `NameError: name 'db' is not defined`. Restoring the
+        signature (frame, db) — matching the existing tests — fixes startup.
+        """
         from app.models.system_setting import SystemSetting
         from app.services.ocr_service import extract_overlay_text, is_ocr_available
 

--- a/scripts/deploy-baremetal.sh
+++ b/scripts/deploy-baremetal.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# ArgusAI bare-metal (systemd) deploy — safe pull → migrate → restart → verify.
+#
+# Codifies the correct deploy sequence so deploys cannot skip database
+# migrations (the root cause of the 2026-06-28 login 500: a refresh-token
+# migration was never applied to prod) and so health is actually verified
+# before the deploy is declared done (a crash loop can leave systemd reporting
+# "active" mid-restart — see the NRestarts check below).
+#
+# Usage (run on the production server, e.g. argusai.bengtson.local):
+#   sudo ./scripts/deploy-baremetal.sh
+#
+# Env overrides:
+#   APP_DIR (default /ArgusAI)   BACKEND_SVC (default argusai-backend)
+#   FRONTEND_SVC (default argusai-frontend)   HEALTH_URL (default http://127.0.0.1:8000/health)
+#   REBUILD_FRONTEND=1 to force a frontend npm build + restart
+set -Eeuo pipefail
+
+APP_DIR="${APP_DIR:-/ArgusAI}"
+BACKEND_SVC="${BACKEND_SVC:-argusai-backend}"
+FRONTEND_SVC="${FRONTEND_SVC:-argusai-frontend}"
+HEALTH_URL="${HEALTH_URL:-http://127.0.0.1:8000/health}"
+
+log() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
+die() { printf '\n\033[1;31mDEPLOY FAILED: %s\033[0m\n' "$*" >&2; exit 1; }
+
+cd "$APP_DIR" || die "APP_DIR $APP_DIR not found"
+
+OLD_REF="$(git rev-parse --short HEAD)"
+log "Current revision: $OLD_REF"
+
+# --- 1. Pull ---------------------------------------------------------------
+log "Pulling latest (fast-forward only)"
+git pull --ff-only || die "git pull failed (diverged history?)"
+NEW_REF="$(git rev-parse --short HEAD)"
+log "New revision: $NEW_REF"
+if [ "$OLD_REF" = "$NEW_REF" ]; then
+  log "No new commits. Continuing (will still verify migrations + health)."
+fi
+
+# Detect what changed so we only rebuild the frontend when needed.
+CHANGED="$(git diff --name-only "$OLD_REF" "$NEW_REF" 2>/dev/null || true)"
+DEPS_CHANGED="$(echo "$CHANGED" | grep -E '^backend/requirements.txt$' || true)"
+FRONTEND_CHANGED="$(echo "$CHANGED" | grep -E '^frontend/' || true)"
+
+# --- 2. Backend deps + MIGRATION GATE -------------------------------------
+cd "$APP_DIR/backend"
+# shellcheck disable=SC1091
+source venv/bin/activate || die "could not activate backend venv"
+
+if [ -n "$DEPS_CHANGED" ]; then
+  log "requirements.txt changed — installing backend deps"
+  pip install -r requirements.txt || die "pip install failed"
+fi
+
+# Back up the SQLite DB (if SQLite) before migrating — instant rollback point.
+DB_URL="$(python -c 'from app.core.config import settings; print(settings.DATABASE_URL)')"
+if [[ "$DB_URL" == sqlite* ]]; then
+  DB_PATH="${DB_URL#sqlite:///}"
+  if [ -f "$DB_PATH" ]; then
+    BK="${DB_PATH}.bak.$(date +%Y%m%d-%H%M%S)"
+    cp "$DB_PATH" "$BK" && log "DB backed up: $BK"
+  fi
+fi
+
+log "Applying database migrations (alembic upgrade head) — THE GATE"
+alembic upgrade head || die "alembic upgrade failed — NOT restarting (DB unchanged-safe)"
+
+# --- 3. Frontend (only if changed or forced) ------------------------------
+if [ -n "$FRONTEND_CHANGED" ] || [ "${REBUILD_FRONTEND:-0}" = "1" ]; then
+  log "Frontend changed — npm ci + build"
+  cd "$APP_DIR/frontend"
+  npm ci || die "npm ci failed"
+  npm run build || die "frontend build failed"
+fi
+
+# --- 4. Restart services ---------------------------------------------------
+log "Restarting $BACKEND_SVC"
+systemctl restart "$BACKEND_SVC" || die "failed to restart $BACKEND_SVC"
+if [ -n "$FRONTEND_CHANGED" ] || [ "${REBUILD_FRONTEND:-0}" = "1" ]; then
+  log "Restarting $FRONTEND_SVC"
+  systemctl restart "$FRONTEND_SVC" || die "failed to restart $FRONTEND_SVC"
+fi
+
+# --- 5. Verify health (poll /health AND confirm no crash loop) -------------
+log "Verifying backend health (a bare 'active' can lie mid-restart)"
+R0="$(systemctl show "$BACKEND_SVC" -p NRestarts --value)"
+HEALTHY=0
+for i in $(seq 1 30); do
+  if [ "$(curl -s -o /dev/null -w '%{http_code}' "$HEALTH_URL" 2>/dev/null)" = "200" ]; then
+    HEALTHY=1; log "Health 200 after ~$((i*3))s"; break
+  fi
+  sleep 3
+done
+[ "$HEALTHY" = "1" ] || die "health never returned 200 — backend likely crash-looping. Inspect: journalctl -u $BACKEND_SVC -n 50"
+
+sleep 12
+R1="$(systemctl show "$BACKEND_SVC" -p NRestarts --value)"
+[ "$R0" = "$R1" ] || die "NRestarts climbing ($R0 -> $R1) — crash loop after startup. Inspect: journalctl -u $BACKEND_SVC -n 50"
+
+log "Deploy OK: $OLD_REF -> $NEW_REF, migrations at head, $BACKEND_SVC healthy and stable."


### PR DESCRIPTION
## Context
Follow-up to the production login-500 incident. While fixing that (a never-applied refresh-token migration), two more active refactor regressions surfaced in prod logs. This PR fixes both and adds guards so the whole class of incident can't recur.

## Bug fixes
**1. `protect_event_handler.py` — `NameError: name 'db' is not defined`**
A refactor dropped the `def _try_ocr_extraction(self, frame, db):` line but left the method body, orphaning it inside `__init__`. Constructing `ProtectEventHandler()` therefore crashed on **every Protect WebSocket event**. Restored the method signature (the existing tests at `test_protect_event_handler.py:743/757` already call it with `(frame, db)`).
- Impact: un-blocked **37 previously-erroring tests** in the affected suites (14 → 51 passing; the `_try_ocr_extraction` OCR tests now pass). The remaining failures in those suites are pre-existing — they were *errors* (couldn't run) before, now they run.

**2. `camera_task_manager.py` — `AttributeError: 'CameraTaskManager' object has no attribute 'motion_task_stats'`**
`handle_unhealthy_camera_worker` used `self.motion_task_stats`; the attribute is `self._motion_task_stats` (definition line 57, used correctly everywhere else). Fired ~every 10s per camera and broke unhealthy-camera recovery. One-char fix.

## Deploy guards (prevent recurrence)
**`ci.yml` — new `startup-smoke` job on Python 3.12** (matches prod):
- `python -c "import main"` — catches import-time `NameError` from missing `typing` imports, **masked locally on Python 3.14** by PEP 649 deferred annotation eval but fatal on prod's 3.12.
- `alembic upgrade head` on a fresh DB — catches broken migrations.

**`scripts/deploy-baremetal.sh`** — codifies the safe sequence: pull → DB backup → **`alembic upgrade head` (migration GATE)** → restart → verify `/health` 200 **and** stable `NRestarts`. The missing migration gate is exactly what caused the login 500; the health/NRestarts check is what caught the earlier crash loop.

## Verification
- Local (Python 3.14): `ProtectEventHandler()` constructs cleanly; `_try_ocr_extraction` is a callable method; `camera_task_manager` uses `_motion_task_stats`.
- Targeted suites: 14 → 51 passing (no previously-passing test regressed).
- `ci.yml` parses; `deploy-baremetal.sh` passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)