### PR TITLE
fix(alembic): honor DATABASE_URL over static alembic.ini url

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -9,6 +9,7 @@ from alembic import context
 # Import Base and all models to ensure they're registered
 from app.core.database import Base
 from app.models import Camera, HotCameraActivity, HotEntityActivity  # Import all models here
+from app.core.config import settings
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -18,6 +19,19 @@ config = context.config
 # This line sets up loggers basically.
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
+
+# Always target the SAME database the application uses. `settings.DATABASE_URL`
+# is sourced from the DATABASE_URL env var (see app.core.config), so this makes
+# `DATABASE_URL=... alembic upgrade head` actually take effect — for CI, for
+# testing a migration against a *copy* of a DB, and for prod alike.
+#
+# Previously both env.py paths read only the static alembic.ini `sqlalchemy.url`,
+# so DATABASE_URL was silently ignored — which made "test against a copy first"
+# unknowingly run against the real database. The `%` -> `%%` escape protects
+# ConfigParser interpolation for URLs that contain a literal '%' (e.g. an
+# encoded password in a Postgres DSN).
+if settings.DATABASE_URL:
+    config.set_main_option("sqlalchemy.url", settings.DATABASE_URL.replace("%", "%%"))
 
 # add your model's MetaData object here
 # for 'autogenerate' support


### PR DESCRIPTION
## Why
`alembic/env.py` read the DB URL only from the static `alembic.ini` `sqlalchemy.url` (both the offline path, line 44, and the online path, lines 63-64). So `DATABASE_URL=... alembic upgrade head` was **silently ignored**.

During today's events schema-drift fix this bit me directly: a run intended to test the migration **against a copy** of the prod DB unknowingly executed against the **real** database (it was safe — additive `ADD COLUMN` + fresh backup + verified zero data loss — but it's a footgun worth removing).

## Fix
`env.py` now sets `sqlalchemy.url` from `settings.DATABASE_URL` (which pydantic sources from the `DATABASE_URL` env var). Alembic now always migrates the same database the app connects to. `%` → `%%` escaping protects ConfigParser interpolation for URLs with a literal `%`.

## Impact
- **Prod: no change** — `settings.DATABASE_URL` == the ini URL == `./data/app.db`.
- **CI:** the new `startup-smoke` `alembic upgrade head` step now runs against its intended throwaway DB.
- **Copy-tests** (`DATABASE_URL=sqlite:///copy.db alembic upgrade head`) now work as expected.

## Verification
`DATABASE_URL=sqlite:///throwaway.db alembic upgrade head` builds the full schema **at that path** (previously it ignored the override). Migration chain applies cleanly base→head, including the recent event-columns migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)