### PR TITLE
fix(events): add missing prompt_variant field to EventResponse (events 500)

### DIFF
--- a/backend/app/api/v1/events.py
+++ b/backend/app/api/v1/events.py
@@ -590,6 +590,7 @@ def list_events(
                 "correlation_group_id": event.correlation_group_id,
                 "correlated_events": None,
                 "provider_used": event.provider_used,
+                "prompt_variant": getattr(event, 'prompt_variant', None),
                 "fallback_reason": event.fallback_reason,
                 "analysis_mode": event.analysis_mode,
                 "frame_count_used": event.frame_count_used,

--- a/backend/app/schemas/event.py
+++ b/backend/app/schemas/event.py
@@ -260,6 +260,8 @@ class EventResponse(BaseModel):
     ocr_used: bool = Field(default=False, description="Whether overlay text was extracted from the video frame and provided to the AI")
     # Surfaced from AIProcessingCoordinator: whether fallback occurred
     ai_fallback_used: bool = Field(default=False, description="True if the AI call fell back to a secondary provider")
+    # A/B prompt experiment variant (surfaced from coordinator; consumed by AIEconomics)
+    prompt_variant: Optional[str] = Field(None, description="Prompt variant used for the AI vision call ('control'/'experiment'; null = no A/B test active)")
     # Story P4-3.4: Rich early entity match metadata (surfaced from coordinator)
     entity_similarity_score: Optional[float] = Field(None, description="Similarity score of the matched entity from early embedding (0.0-1.0)")
     entity_occurrence_count: Optional[int] = Field(None, description="Number of previous sightings of this entity")


### PR DESCRIPTION
## Incident
`GET /api/v1/events?offset=0&limit=20` returned **500** (browser console). After the schema-drift migration fixed the DB columns, the events serializer hit a **different** bug:

```
'EventResponse' object has no attribute 'prompt_variant'
  schemas/event.py:396  populate_ai_economics:  prompt_variant=self.prompt_variant
```

## Root cause
The `populate_ai_economics` model validator reads `self.prompt_variant`, but `EventResponse` **never declared** that field — a refactor added the validator reference without the field. (The `Event` model has the `prompt_variant` `String(20)` column, and `AIEconomics` expects it.)

## Fix
- `schemas/event.py`: declare `prompt_variant: Optional[str]` on `EventResponse` — fixes the crash at every construction site (defaults to `None` when not supplied).
- `api/v1/events.py`: pass `event.prompt_variant` through the `list_events` `event_dict` so the real value reaches `AIEconomics`.

## Verification
`EventResponse(**d)` constructs both with and without `prompt_variant`; `ai_economics.prompt_variant` is populated from the flat field. (Runtime validator error, so it reproduces on local Python 3.14 — unlike the import-time bugs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)