### PR TITLE
fix(api): two 500s from endpoint sweep (context/vehicles, ai-resilience)

### DIFF
--- a/backend/app/schemas/system.py
+++ b/backend/app/schemas/system.py
@@ -578,7 +578,11 @@ class CircuitBreakerStatusResponse(BaseModel):
 
 class AIResilienceResponse(BaseModel):
     """Full AI Resilience status"""
-    default: CircuitBreakerStatusResponse
+    # Optional so the endpoint degrades gracefully (HTTP 200) when the
+    # AIResilienceService is not initialized — in that case the service layer
+    # returns just {"last_reset": None}. A required `default` made FastAPI raise
+    # ResponseValidationError -> 500 on GET /api/v1/system/ai-resilience.
+    default: Optional[CircuitBreakerStatusResponse] = None
     openai: Optional[CircuitBreakerStatusResponse] = None
     grok: Optional[CircuitBreakerStatusResponse] = None
     claude: Optional[CircuitBreakerStatusResponse] = None

--- a/backend/app/services/vehicle_matching_service.py
+++ b/backend/app/services/vehicle_matching_service.py
@@ -888,9 +888,13 @@ class VehicleMatchingService:
         result = []
         for v in vehicles:
             metadata = {}
-            if v.metadata:
+            # NOTE: must use `entity_metadata` (the Text/JSON column), NOT `.metadata`
+            # — `.metadata` is SQLAlchemy's reserved MetaData attribute on every ORM
+            # object, which made `json.loads(v.metadata)` raise TypeError and 500 the
+            # /api/v1/context/vehicles endpoint.
+            if v.entity_metadata:
                 try:
-                    metadata = json.loads(v.metadata)
+                    metadata = json.loads(v.entity_metadata)
                 except json.JSONDecodeError:
                     pass
 


### PR DESCRIPTION
## Proactive endpoint sweep
Ran a full authenticated GET sweep against the live prod server (Python 3.12, real data): **132 GET routes, 98 returned 2xx**. Exactly **2 true 500s** found and fixed here.

### 1. `GET /api/v1/context/vehicles` — 500
```
TypeError: the JSON object must be str, bytes or bytearray, not MetaData
  vehicle_matching_service.py:893  get_vehicles:  json.loads(v.metadata)
```
`v.metadata` is SQLAlchemy's reserved `MetaData` attribute on every ORM object — not a column. The JSON column is **`entity_metadata`** (`Text`). Fixed to `v.entity_metadata` (matches `entity_alert_service.py:426`).

### 2. `GET /api/v1/system/ai-resilience` — 500
```
ResponseValidationError: ('response','default') Field required  (input {'last_reset': None})
```
When `AIResilienceService` isn't initialized, the service returns the stub `{"last_reset": None}`, but `AIResilienceResponse.default` was **required**. Made `default` `Optional` (consistent with the already-Optional per-provider fields) so the endpoint returns **200** in the degraded case instead of 500.

## Verified
- `AIResilienceResponse(**{"last_reset": None})` now validates.
- `vehicle_matching_service` imports; `RecognizedEntity.entity_metadata` exists.
- Will re-run the sweep post-deploy to confirm both are 2xx.

## Not in this PR (noted for follow-up)
- 503 on `homekit/cameras/{id}/snapshot` — legitimate device-state, not a code bug.
- 2 endpoint timeouts + 1 ~79MB oversized response — performance, not 500s.
- `AIResilienceService` being uninitialized on prod (why the stub is hit) is a separate, deeper question worth investigating — this PR just stops the 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)