### PR TITLE
fix(ai): lazily configure providers in ai-resilience status endpoint

### DIFF
--- a/backend/app/api/v1/system.py
+++ b/backend/app/api/v1/system.py
@@ -3081,6 +3081,13 @@ async def get_ai_resilience_status(db: Session = Depends(get_db)):
     Used by the AI Resilience settings page.
     """
     try:
+        # AI provider wiring (incl. the resilience service + circuit breakers) is
+        # lazy — it only runs on the first AI processing call (event_processor,
+        # reanalyze, etc.), not at startup. A freshly-restarted process that has
+        # not yet processed an AI event would otherwise report an empty stub.
+        # Ensure it's configured so admins see real circuit-breaker state.
+        if container.ai_service.resilience_service is None:
+            await container.ai_service.load_api_keys_from_db(db)
         return container.ai_service.get_ai_resilience_status(db)
     except Exception as e:
         logger.error(f"Failed to get AI resilience status: {e}", exc_info=True)


### PR DESCRIPTION
## Chase #2 — why `AIResilienceService` was uninitialized on prod

**Root cause (not a broken init — a lazy one):** `AIService` wires `resilience_service` + circuit breakers inside `configure_providers()`, which only runs via `load_api_keys_from_db()` on the **first AI processing call** (event_processor, reanalyze, …). It is **never called at startup** — `main.py` just does `AIService()`. So a freshly-restarted process that hasn't yet processed an AI event has `resilience_service = None`, and the status endpoint read it without triggering config → empty stub `{"last_reset": None}` (which, before the earlier schema fix, 500'd).

**Important:** circuit-breaker *protection* was never broken — it's wired and active whenever AI calls actually run. Only this **read-only status endpoint** showed an empty view before the first AI call of the process lifetime.

## Fix
The `/ai-resilience` handler now calls `load_api_keys_from_db()` when `resilience_service is None`, so it lazily configures providers and returns **real** circuit-breaker state. With the earlier `Optional[default]` schema change as a backstop, the endpoint is robust whether or not AI keys are configured.

## Chase #1 (reported here, no code change) — the "79MB / timeouts"
A streaming perf sweep (117 routes) showed these were **not bugs**:
- `system/ai-processing-stream` + `ai-processing-hot-stream` — **SSE streams** (intentionally long-lived; the sweep just held them open). Real clients use `EventSource`.
- `/api/v1/logs/download` — **82MB**, a deliberate "download full logs" endpoint (0.01s ttfb). By-design, but **unbounded** — a real OOM risk as logs grow against the 1Gi pod limit. Worth a size/tail cap in a follow-up (not changed here — it's an intentional feature).

Everything else was <1.5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)