### PR TITLE
fix(ai): import AIProvider in ai_resilience_service (NameError)

### DIFF
--- a/backend/app/services/ai_resilience_service.py
+++ b/backend/app/services/ai_resilience_service.py
@@ -42,6 +42,7 @@ from app.services.ai_circuit_breaker import (
     CircuitBreakerConfig,
     CircuitState,
 )
+from app.services.ai_types import AIProvider  # used in get_ai_resilience_status / reset (was missing -> NameError)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Third bug behind `GET /api/v1/system/ai-resilience`: `get_ai_resilience_status()` uses `AIProvider[p.upper()]` (lines 232, 303) but never imported `AIProvider`, so the builder raised `NameError` on the openai iteration whenever `resilience_service` was set. Added `from app.services.ai_types import AIProvider`.

With this + the earlier Optional-`default` schema fix + lazy-init, the endpoint returns the real circuit-breaker structure instead of 500/stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)