### PR TITLE
fix(ai): restore provider construction — AI description generation is down on prod

### DIFF
--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -267,6 +267,27 @@ class AIService:
         self.resilience_service = AIResilienceService()
         # Note: circuit breakers are initialized later when providers are known
 
+        # Construct provider clients from the supplied keys. This block was
+        # dropped in the #443-#450 ai_service decomposition, leaving
+        # self.providers permanently empty (0 providers => no AI descriptions).
+        # Restored to match the original AIService.configure_providers behavior.
+        from app.services.ai_providers import (
+            OpenAIProvider,
+            GrokProvider,
+            ClaudeProvider,
+            GeminiProvider,
+        )
+        self.providers = {}
+        if openai_key:
+            self.providers[AIProvider.OPENAI] = OpenAIProvider(openai_key)
+        if grok_key:
+            self.providers[AIProvider.GROK] = GrokProvider(grok_key)
+        if claude_key:
+            self.providers[AIProvider.CLAUDE] = ClaudeProvider(claude_key, claude_model)
+        if gemini_key:
+            self.providers[AIProvider.GEMINI] = GeminiProvider(gemini_key)
+        logger.info(f"Constructed {len(self.providers)} AI provider client(s)")
+
         # Wire prompt service
         self.prompt_service = AIPromptService(
             default_prompt=self.description_prompt,


### PR DESCRIPTION
## ⚠️ Critical: AI description generation is non-functional on prod

While chasing why `/api/v1/system/ai-resilience` was uninitialized, I found the real root cause: **`configure_providers` builds 0 providers**, so the vision orchestrator has nothing to call — **no AI descriptions are generated at all**.

### Root cause
The **#443–#450 `ai_service` decomposition** (`1af9f8a`/`bd5fce9`) dropped the block that constructs provider clients from the API keys. `self.providers` is initialized `{}` and never populated. A follow-up `6f54c85 "repair broken wiring"` did not restore it (it removed more wiring). The bug was masked because prod ran a long-lived pre-refactor process; the restarts this session exposed it.

Confirmed on prod:
- All 4 keys are in the DB and **decrypt correctly** (`sk-`, `xai-`, `AIza`, `sk-ant` prefixes).
- Logs: `AI providers configured: 0 providers loaded`.
- `vision_orchestrator.providers == 0`.

This also explains the `ai-resilience` endpoint showing an empty status.

### Fix
Restore the provider-construction block in `configure_providers` (matches the pre-refactor code + current constructor signatures), keyed by `AIProvider`, handed to the orchestrator via the existing `set_providers()`.

### Verified (no API cost)
With dummy keys: `configure_providers` → **4 providers** (`claude, gemini, grok, openai`); `vision_orchestrator.providers == 4`. Instantiation only — no network calls.

### ⚠️ Cost note
Deploying this **re-enables AI processing and provider spend** on prod (as designed — the user has all 4 keys configured). Holding deploy for explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)