### PR TITLE
fix(ai): get_ai_service() returns the shared instance (fragmentation)

### DIFF
--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -714,17 +714,21 @@ class AIService:
 ai_service = AIService()
 
 
-# Backward compatible thin getter (delegates to @singleton decorator)
 def get_ai_service() -> AIService:
     """
-    Get the global AIService instance.
+    Get the shared global AIService instance.
 
-    Note: This is now a thin backward-compatible wrapper.
-          New code should prefer AIService() directly.
+    IMPORTANT: must return the module-global `ai_service`, NOT a fresh
+    `AIService()`. AIService is not a singleton, and a fresh instance is
+    unconfigured (no providers, no resilience service). Returning a new instance
+    each call caused instance fragmentation: e.g. the /ai-resilience endpoint
+    configured one throwaway instance via load_api_keys_from_db and then read
+    resilience state from a different (unconfigured) instance -> empty status.
     """
-    return AIService()
+    return ai_service
 
 
 def reset_ai_service() -> None:
     """Reset the global AIService instance (for testing)."""
-    AIService._reset_instance()
+    global ai_service
+    ai_service = AIService()


### PR DESCRIPTION
## Bug (found verifying the provider-construction fix #488)
After #488 restored provider construction, the prod log showed **"4 providers loaded"** — yet `/api/v1/system/ai-resilience` *still* returned an empty status. Root cause: **instance fragmentation**.

`get_ai_service()` returned `AIService()` (a fresh, unconfigured instance) on every call instead of the module-global `ai_service`. Since `AIService` isn't a singleton, every `container.ai_service` access yielded a *different* empty instance. The endpoint configured one throwaway instance (`load_api_keys_from_db` built 4 providers on it) and then read status from a *different* unconfigured one → empty.

## Fix
- `get_ai_service()` → return the existing module-global `ai_service`.
- `reset_ai_service()` → rebind that global (the old `AIService._reset_instance()` would have raised; AIService has no such method).

## Verified
Configuring via one `container.ai_service` access exposes the 4 providers + resilience service via any later access (previously 0). `get_ai_service()` is stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)