### PR TITLE
feat(ai): dynamic vision-model resolution (self-healing models)

### DIFF
--- a/backend/app/services/ai_providers/claude_provider.py
+++ b/backend/app/services/ai_providers/claude_provider.py
@@ -20,7 +20,8 @@ class ClaudeProvider(AIProviderBase):
     def __init__(self, api_key: str, model: str = None):
         super().__init__(api_key)
         self.client = anthropic.AsyncAnthropic(api_key=api_key)
-        self.model = model or "claude-3-haiku-20240307"
+        from app.services.ai_providers.model_resolver import resolve_model
+        self.model = resolve_model("claude", api_key, override=model)
         self.cost_per_1k_input_tokens = 0.00025
         self.cost_per_1k_output_tokens = 0.00125
 

--- a/backend/app/services/ai_providers/gemini_provider.py
+++ b/backend/app/services/ai_providers/gemini_provider.py
@@ -19,10 +19,12 @@ from app.services.ocr_service import OCRResult
 class GeminiProvider(AIProviderBase):
     """Google Gemini Flash vision provider"""
 
-    def __init__(self, api_key: str):
+    def __init__(self, api_key: str, model: str = None):
         super().__init__(api_key)
         genai.configure(api_key=api_key)
-        self.model = genai.GenerativeModel('gemini-1.5-flash')
+        from app.services.ai_providers.model_resolver import resolve_model
+        self.model_name = resolve_model("gemini", api_key, override=model)
+        self.model = genai.GenerativeModel(self.model_name)
         self.cost_per_1k_input_tokens = 0.000075
         self.cost_per_1k_output_tokens = 0.0003
 

--- a/backend/app/services/ai_providers/grok_provider.py
+++ b/backend/app/services/ai_providers/grok_provider.py
@@ -18,13 +18,14 @@ from app.services.prompt_templates import MULTI_FRAME_SYSTEM_PROMPT
 class GrokProvider(AIProviderBase):
     """xAI Grok vision provider (OpenAI-compatible API)"""
 
-    def __init__(self, api_key: str):
+    def __init__(self, api_key: str, model: str = None):
         super().__init__(api_key)
         self.client = openai.AsyncOpenAI(
             api_key=api_key,
             base_url="https://api.x.ai/v1"
         )
-        self.model = "grok-2-vision-1212"
+        from app.services.ai_providers.model_resolver import resolve_model
+        self.model = resolve_model("grok", api_key, override=model)
         self.cost_per_1k_input_tokens = 0.00010
         self.cost_per_1k_output_tokens = 0.00040
 

--- a/backend/app/services/ai_providers/model_resolver.py
+++ b/backend/app/services/ai_providers/model_resolver.py
@@ -1,0 +1,140 @@
+"""
+Dynamic vision-model resolution for AI providers.
+
+Provider model IDs get deprecated over time (e.g. Gemini's `gemini-1.5-flash`
+returned 404, Claude's `claude-3-haiku-20240307` was retired). Hardcoding a
+single model means AI silently breaks the day a model is sunset. This resolver
+picks a currently-available vision-capable model for each provider, so the
+system self-heals as model line-ups change.
+
+Resolution order (per provider):
+  1. explicit `override` (admin pin, e.g. a SystemSetting) — always wins
+  2. dynamic query of the provider's "list models" API, filtered to a
+     preference list of cheap vision-capable models (result cached per process)
+  3. a current, known-good fallback constant (so AI still works if the network
+     query fails)
+
+The dynamic query uses a short timeout and is cached, so the cost is at most one
+brief lookup per provider per process. Fallbacks are kept current so behavior is
+correct even when the query is skipped or fails.
+"""
+import logging
+import threading
+import time
+from typing import List, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Preference order (substring match, best/cheapest-first) of vision-capable models.
+_PREFERENCES = {
+    "openai": ["gpt-4o-mini", "gpt-4.1-mini", "gpt-4o", "gpt-4.1"],
+    "grok": ["grok-4.3", "grok-4", "grok-3", "grok-2-vision", "grok-vision"],
+    "claude": ["claude-haiku-4-5", "claude-3-5-haiku", "claude-haiku", "claude-3-haiku"],
+    "gemini": ["gemini-flash-latest", "gemini-2.0-flash", "gemini-2.5-flash", "gemini-flash"],
+}
+
+# Exclude non-text-vision models (image generation, tts, embeddings, etc.).
+_EXCLUDE_SUBSTRINGS = ("imagine", "image", "video", "tts", "embed", "embedding",
+                       "transcribe", "search", "build", "audio", "realtime")
+
+# Current, known-good defaults (verified available 2026-06). Used if the dynamic
+# query fails. Gemini's `-latest` alias auto-updates and is the safest default.
+_FALLBACKS = {
+    "openai": "gpt-4o-mini",
+    "grok": "grok-4.3",
+    "claude": "claude-haiku-4-5-20251001",
+    "gemini": "gemini-flash-latest",
+}
+
+_LIST_TIMEOUT_S = 5.0
+_CACHE_TTL_S = 6 * 3600
+_cache: dict = {}          # provider -> (model, resolved_at)
+_lock = threading.Lock()
+
+
+def _list_models(provider: str, api_key: str) -> List[str]:
+    """Return the provider's available model IDs (raises on network/auth error)."""
+    with httpx.Client(timeout=_LIST_TIMEOUT_S) as c:
+        if provider == "openai":
+            r = c.get("https://api.openai.com/v1/models",
+                      headers={"Authorization": f"Bearer {api_key}"})
+            r.raise_for_status()
+            return [m["id"] for m in r.json().get("data", [])]
+        if provider == "grok":
+            r = c.get("https://api.x.ai/v1/models",
+                      headers={"Authorization": f"Bearer {api_key}"})
+            r.raise_for_status()
+            return [m["id"] for m in r.json().get("data", [])]
+        if provider == "claude":
+            r = c.get("https://api.anthropic.com/v1/models",
+                      headers={"x-api-key": api_key, "anthropic-version": "2023-06-01"})
+            r.raise_for_status()
+            return [m["id"] for m in r.json().get("data", [])]
+        if provider == "gemini":
+            r = c.get(f"https://generativelanguage.googleapis.com/v1beta/models?key={api_key}")
+            r.raise_for_status()
+            return [m["name"].replace("models/", "") for m in r.json().get("models", [])]
+    return []
+
+
+def _pick(provider: str, available: List[str]) -> Optional[str]:
+    """Pick the best available model for a provider by preference order."""
+    candidates = [m for m in available
+                  if not any(x in m.lower() for x in _EXCLUDE_SUBSTRINGS)]
+    for pref in _PREFERENCES.get(provider, []):
+        for m in candidates:
+            if pref in m:
+                return m
+    return None
+
+
+def list_available_models(provider: str, api_key: str) -> List[str]:
+    """Public helper for an admin "what models are available" view.
+
+    Returns the vision-capable candidates (preferred ones first), or [] on error.
+    """
+    try:
+        available = _list_models(provider, api_key)
+    except Exception as e:  # noqa: BLE001 - best-effort listing
+        logger.warning("model_resolver: list_available_models(%s) failed: %s", provider, e)
+        return []
+    candidates = [m for m in available
+                  if not any(x in m.lower() for x in _EXCLUDE_SUBSTRINGS)]
+    preferred = [m for pref in _PREFERENCES.get(provider, []) for m in candidates if pref in m]
+    seen = set()
+    ordered = [m for m in preferred + candidates if not (m in seen or seen.add(m))]
+    return ordered
+
+
+def resolve_model(provider: str, api_key: str, override: Optional[str] = None) -> str:
+    """Resolve the model ID to use for a provider (see module docstring)."""
+    if override and override.strip():
+        return override.strip()
+
+    now = time.time()
+    with _lock:
+        cached = _cache.get(provider)
+        if cached and (now - cached[1]) < _CACHE_TTL_S:
+            return cached[0]
+
+    model = _FALLBACKS.get(provider, "")
+    try:
+        picked = _pick(provider, _list_models(provider, api_key))
+        if picked:
+            model = picked
+    except Exception as e:  # noqa: BLE001 - fall back to known-good default
+        logger.warning("model_resolver: dynamic resolve(%s) failed (%s); using fallback %s",
+                       provider, e, model)
+
+    with _lock:
+        _cache[provider] = (model, now)
+    logger.info("model_resolver: %s -> %s", provider, model)
+    return model
+
+
+def clear_cache() -> None:
+    """Drop cached resolutions (e.g. after an admin changes the model override)."""
+    with _lock:
+        _cache.clear()

--- a/backend/app/services/ai_providers/openai_provider.py
+++ b/backend/app/services/ai_providers/openai_provider.py
@@ -17,10 +17,11 @@ from app.services.ocr_service import OCRResult
 class OpenAIProvider(AIProviderBase):
     """OpenAI GPT-4o mini vision provider"""
 
-    def __init__(self, api_key: str):
+    def __init__(self, api_key: str, model: str = None):
         super().__init__(api_key)
         self.client = openai.AsyncOpenAI(api_key=api_key)
-        self.model = "gpt-4o-mini"
+        from app.services.ai_providers.model_resolver import resolve_model
+        self.model = resolve_model("openai", api_key, override=model)
         self.cost_per_1k_input_tokens = 0.00015
         self.cost_per_1k_output_tokens = 0.00060
 

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -125,6 +125,12 @@ class AIService:
                     'settings_ab_test_prompt',  # Story P4-5.4: Experiment prompt
                     'enable_ai_annotations',  # Story P15-5.1: Enable bounding box annotations
                     'use_litellm',  # LiteLLM Integration: Use unified provider
+                    # Optional per-provider model overrides (pin a specific model);
+                    # when unset, each provider resolves a current model dynamically.
+                    'settings_openai_model',
+                    'settings_grok_model',
+                    'settings_claude_model',
+                    'settings_gemini_model',
                 ])
             ).all()
 
@@ -199,10 +205,16 @@ class AIService:
                 gemini_key = decrypt_password(keys['ai_api_key_gemini'])
                 logger.info("Gemini API key loaded from database")
 
-            # Load Claude model selection
-            claude_model = keys.get('settings_claude_model', None)
-            if claude_model:
-                logger.info(f"Claude model setting loaded: {claude_model}")
+            # Optional per-provider model overrides (pin a specific model).
+            # When unset, each provider dynamically resolves a current model.
+            openai_model = keys.get('settings_openai_model') or None
+            grok_model = keys.get('settings_grok_model') or None
+            claude_model = keys.get('settings_claude_model') or None
+            gemini_model = keys.get('settings_gemini_model') or None
+            for _name, _val in (("openai", openai_model), ("grok", grok_model),
+                                ("claude", claude_model), ("gemini", gemini_model)):
+                if _val:
+                    logger.info(f"{_name} model override loaded: {_val}")
 
             # Configure providers with decrypted keys
             self.configure_providers(
@@ -210,7 +222,10 @@ class AIService:
                 grok_key=grok_key,
                 claude_key=claude_key,
                 gemini_key=gemini_key,
-                claude_model=claude_model
+                claude_model=claude_model,
+                openai_model=openai_model,
+                grok_model=grok_model,
+                gemini_model=gemini_model,
             )
 
             logger.info(f"AI providers configured: {len(self.providers)} providers loaded")
@@ -248,7 +263,10 @@ class AIService:
         grok_key: Optional[str] = None,
         claude_key: Optional[str] = None,
         gemini_key: Optional[str] = None,
-        claude_model: Optional[str] = None
+        claude_model: Optional[str] = None,
+        openai_model: Optional[str] = None,
+        grok_model: Optional[str] = None,
+        gemini_model: Optional[str] = None,
     ):
         """
         Configure AI providers with API keys.
@@ -277,15 +295,18 @@ class AIService:
             ClaudeProvider,
             GeminiProvider,
         )
+        # Each provider resolves a current vision model dynamically (see
+        # ai_providers/model_resolver.py); the optional *_model overrides pin a
+        # specific model (from SystemSetting) when provided.
         self.providers = {}
         if openai_key:
-            self.providers[AIProvider.OPENAI] = OpenAIProvider(openai_key)
+            self.providers[AIProvider.OPENAI] = OpenAIProvider(openai_key, openai_model)
         if grok_key:
-            self.providers[AIProvider.GROK] = GrokProvider(grok_key)
+            self.providers[AIProvider.GROK] = GrokProvider(grok_key, grok_model)
         if claude_key:
             self.providers[AIProvider.CLAUDE] = ClaudeProvider(claude_key, claude_model)
         if gemini_key:
-            self.providers[AIProvider.GEMINI] = GeminiProvider(gemini_key)
+            self.providers[AIProvider.GEMINI] = GeminiProvider(gemini_key, gemini_model)
         logger.info(f"Constructed {len(self.providers)} AI provider client(s)")
 
         # Wire prompt service


### PR DESCRIPTION
## Why
AI generation was failing on **deprecated hardcoded model IDs** — Gemini `gemini-1.5-flash` → 404, Claude `claude-3-haiku-20240307` retired, Grok `grok-2-vision-1212` gone (only OpenAI's `gpt-4o-mini` survived). A single hardcoded model breaks AI the day the provider sunsets it.

## What
New `model_resolver.py` resolves each provider's model in priority order:
1. **Override** — `SystemSetting settings_<provider>_model` (admin pin)
2. **Dynamic** — queries the provider's list-models API, filtered to cheap vision-capable models, cached per process with a short timeout
3. **Fallback** — current known-good default (so AI still works if the query fails)

All four providers accept an override and call `resolve_model()`. `configure_providers` + `load_api_keys_from_db` now plumb per-provider overrides for **all four** (the old `settings_claude_model` was never even queried). `list_available_models()` is exposed for an admin "what's available" view.

## Verified
- Resolver picks `gpt-4o-mini` / `grok-4.3` / `claude-haiku-4-5-20251001` / `gemini-flash-latest` from the live model lists; **override wins**; falls back to current valid models when the query is unavailable.
- Full app imports; `configure_providers` builds 4 providers.
- Post-deploy: confirmed a real AI call generates a description (see PR thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)