### PR TITLE
fix(ai): pin CA bundle to certifi — provider SSL was broken (AI down)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,18 @@ FastAPI application entry point for ArgusAI
 Initializes the FastAPI app, registers routers, and sets up startup/shutdown events.
 """
 import os
+
+# --- SSL/CA trust fix (must run before importing app modules) ---
+# A dependency the app loads (google.generativeai / grpc) corrupts the process
+# default SSL trust store, so the httpx-based provider SDKs (OpenAI / xAI Grok /
+# Anthropic) fail every request with CERTIFICATE_VERIFY_FAILED — which silently
+# disabled AI description generation. Pinning the CA bundle to certifi keeps
+# certificate verification working for every HTTP client. setdefault() preserves
+# an explicit operator override (e.g. a corporate CA bundle).
+import certifi as _certifi
+os.environ.setdefault("SSL_CERT_FILE", _certifi.where())
+os.environ.setdefault("REQUESTS_CA_BUNDLE", _certifi.where())
+
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware


### PR DESCRIPTION
## Root cause — the real reason AI was down
OpenAI/xAI/Anthropic calls failed with "Connection error". Traced to **the app import corrupting the process SSL trust store**: a dependency (`google.generativeai` / grpc) alters the default CA path, so every httpx-based provider SDK request fails with `SSL: CERTIFICATE_VERIFY_FAILED: unable to get local issuer certificate`.

**Reproduced exactly:**
```
[before app import] async httpx -> api.openai.com: 401      (TLS OK)
[after  app import] async httpx -> api.openai.com: CERTIFICATE_VERIFY_FAILED
```
Gemini uses gRPC with its own roots, so it was unaffected — which masked the issue and made it look provider-specific.

## Fix
Set `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` to **certifi's bundle** at the very top of `main.py`, before any app import. One env-level fix covers **every** HTTP client (all provider SDKs + the model resolver) with no per-client wiring. `setdefault()` preserves an operator override.

**Verified:** with `SSL_CERT_FILE` set, the async httpx GET returns 401 (TLS OK) even after the corrupting import.

## Combined with the dynamic-model work
This + #490 (dynamic model resolution) together restore real AI generation across all four providers. Real-path reanalyze verification in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)