### PR TITLE
fix(ai): fail fast on quota-exhausted 429 so fallback chain works

### DIFF
--- a/backend/app/services/vision_analysis_orchestrator.py
+++ b/backend/app/services/vision_analysis_orchestrator.py
@@ -544,13 +544,20 @@ class VisionAnalysisOrchestrator:
                 ocr_result=ocr_result
             )
 
-            # Check if rate limited (429) or transient error (500/503)
+            # Check if rate limited (429) or transient error (500/503).
+            # BUT a 429 from quota/billing exhaustion will not recover within the
+            # retry/SLA window — retrying it only burns the SLA budget and starves
+            # the fallback chain (e.g. a working Gemini never gets tried). Treat
+            # those as non-retryable so we fail fast to the next provider.
+            err_str = str(result.error) if result.error else ""
+            quota_exhausted = any(s in err_str.lower() for s in (
+                'insufficient_quota', 'exceeded your current quota', 'billing'))
             is_retryable = (
-                result.error and
+                result.error and not quota_exhausted and
                 (
-                    '429' in str(result.error) or
-                    '500' in str(result.error) or
-                    '503' in str(result.error)
+                    '429' in err_str or
+                    '500' in err_str or
+                    '503' in err_str
                 )
             )
             if is_retryable:
@@ -605,13 +612,17 @@ class VisionAnalysisOrchestrator:
                 ocr_result=ocr_result
             )
 
-            # Check if rate limited (429) or transient error (500/503)
+            # Check if rate limited (429) or transient error (500/503).
+            # Quota/billing 429s won't recover in-window — fail fast (see single-image path).
+            err_str = str(result.error) if result.error else ""
+            quota_exhausted = any(s in err_str.lower() for s in (
+                'insufficient_quota', 'exceeded your current quota', 'billing'))
             is_retryable = (
-                result.error and
+                result.error and not quota_exhausted and
                 (
-                    '429' in str(result.error) or
-                    '500' in str(result.error) or
-                    '503' in str(result.error)
+                    '429' in err_str or
+                    '500' in err_str or
+                    '503' in err_str
                 )
             )
             if is_retryable:


### PR DESCRIPTION
The retry loop treated every 429 as retryable. OpenAI's **429 insufficient_quota** (account out of credits) got backed off 2s+4s and retried — **12s elapsed, blowing the 5s SLA**, so the orchestrator aborted the chain **before trying Grok/Claude/Gemini**. One provider's billing issue took down all AI even though Gemini works.

Fix: quota/billing 429s are non-retryable (fail fast to next provider); genuine rate-limit 429s and 500/503 still retry. Both single- and multi-image paths.

Verified classification: `insufficient_quota`/`exceeded your current quota` → not retried; `rate_limit_exceeded`/500 → retried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)