### PR TITLE
fix(ui): replace removed lucide Chrome icon (frontend build break)

### DIFF
--- a/frontend/components/settings/DeviceManager.tsx
+++ b/frontend/components/settings/DeviceManager.tsx
@@ -20,7 +20,7 @@ import {
   AlertTriangle,
   Loader2,
   Apple,
-  Chrome,
+  Globe,
 } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -69,7 +69,7 @@ function PlatformIcon({ platform }: { platform: string }) {
     case 'android':
       return <Smartphone className="h-4 w-4" />;
     case 'web':
-      return <Chrome className="h-4 w-4" />;
+      return <Globe className="h-4 w-4" />;
     default:
       return <Smartphone className="h-4 w-4" />;
   }


### PR DESCRIPTION
lucide-react 1.16.0 removed brand icons; `Chrome` no longer exists, breaking the production build (`DeviceManager.tsx`). Stale local node_modules masked it; a clean `npm ci` on deploy exposed it. Swapped to `Globe` (valid; 'web' device icon). Verified on prod: lucide 1.16.0 exports Globe/Apple, not Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)