### PR TITLE
fix(protect): correct download_clip kwargs — multi-frame was silently disabled

### DIFF
--- a/backend/app/services/protect_media_service.py
+++ b/backend/app/services/protect_media_service.py
@@ -142,11 +142,17 @@ class ProtectMediaService:
             clip_start = event_timestamp - timedelta(seconds=15)
             clip_end = event_timestamp + timedelta(seconds=15)
 
+            # NOTE: keyword names MUST match ClipService.download_clip's signature
+            # (controller_id, camera_id, event_start, event_end, event_id) where
+            # `camera_id` is the *native Protect* camera id. A prior refactor used
+            # protect_camera_id/start_time/end_time here, which raised TypeError on
+            # EVERY call — silently swallowed below — so clip_path was always None
+            # and the pipeline fell back to single-frame for every event.
             clip_path = await clip_service.download_clip(
                 controller_id=controller_id,
-                protect_camera_id=protect_camera_id,
-                start_time=clip_start,
-                end_time=clip_end,
+                camera_id=protect_camera_id,
+                event_start=clip_start,
+                event_end=clip_end,
                 event_id=event_id,
             )
 
@@ -155,6 +161,16 @@ class ProtectMediaService:
             else:
                 return None, "clip_download_failed"
 
+        except TypeError as e:
+            # A signature/programming error is NOT a transient clip failure. Surface
+            # it loudly (with traceback) so it can never again hide as a routine
+            # warning and silently disable multi-frame analysis.
+            logger.error(
+                f"Clip download call error for camera '{camera_name}' (likely a code/"
+                f"signature bug, not a transient failure): {e}",
+                exc_info=True,
+            )
+            return None, "clip_download_exception"
         except Exception as e:
             logger.warning(f"Clip download failed for camera '{camera_name}': {e}")
             return None, "clip_download_exception"


### PR DESCRIPTION
## Symptom
Only single-frame analysis on Protect events; multi-frame (the better-accuracy default) never happened.

## Root cause (traced, not guessed)
The most recent live event showed `analysis_mode=single_frame`, `fallback_reason=clip_download_exception`. The log gave the exact error:
```
Clip download failed for camera 'Driveway':
ClipService.download_clip() got an unexpected keyword argument 'protect_camera_id'
```
`ProtectMediaService._download_clip` called `download_clip(protect_camera_id=, start_time=, end_time=, ...)`, but the signature is `(controller_id, camera_id, event_start, event_end, event_id)` (camera_id = native Protect id). **Every** live clip download raised `TypeError`, swallowed by a broad `except` into a routine warning → `clip_path=None` → the pipeline (`protect_ai_pipeline`) skips `video_native`+`multi_frame` (both gated on `if clip_path:`) → **single_frame for every event**.

The other two callers (`protect.py:1284`, `events.py:1765` reanalyze) already used the correct names — so only the live pipeline was broken (a refactor mismatch).

## Fix
- Use `camera_id=protect_camera_id`, `event_start`, `event_end`.
- Escalate a `TypeError` from the call to `logger.error(exc_info=True)` — a code/signature bug must not hide as a transient clip failure (that's exactly what masked this).

## Verified
`download_clip` params = {controller_id, camera_id, event_start, event_end, event_id}; the fixed call's kwargs are a valid subset (no TypeError). End-to-end clip-download validation on prod in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)