### PR TITLE
fix(events): reanalyze read wrong controller attr (multi-frame reanalyze 400)

### DIFF
--- a/backend/app/api/v1/events.py
+++ b/backend/app/api/v1/events.py
@@ -1742,8 +1742,11 @@ async def reanalyze_event(
             from app.models.protect_controller import ProtectController
 
             # Find controller by camera's protect_camera_id
+            # NOTE: the Camera column is `protect_controller_id` — reading
+            # `controller_id` always returned None, so multi_frame/video_native
+            # reanalyze 400'd ("not properly configured") for every Protect camera.
             protect_camera_id = getattr(camera, 'protect_camera_id', None)
-            controller_id = getattr(camera, 'controller_id', None)
+            controller_id = getattr(camera, 'protect_controller_id', None) or getattr(camera, 'controller_id', None)
 
             if not protect_camera_id or not controller_id:
                 raise HTTPException(


### PR DESCRIPTION
Reanalyze read `camera.controller_id` to find the Protect controller, but the column is `protect_controller_id`. Always None → multi_frame/video_native reanalyze returned 400 'not properly configured' for every Protect camera. Fix: prefer `protect_controller_id`. Found while validating the clip-download/multi-frame fix (#496).

🤖 Generated with [Claude Code](https://claude.com/claude-code)