### PR TITLE
fix(protect): live multi-frame frame-extraction signature (root cause #2)

### DIFF
--- a/backend/app/api/v1/events.py
+++ b/backend/app/api/v1/events.py
@@ -1834,9 +1834,9 @@ async def reanalyze_event(
             # Extract frames and analyze
             frame_extractor = FrameExtractor()
             extracted_frames = await frame_extractor.extract_frames(
-                video_path=video_path,
-                max_frames=5,
-                skip_blur=True
+                clip_path=video_path,
+                frame_count=5,
+                filter_blur=True
             )
 
             if not extracted_frames:
@@ -1847,11 +1847,16 @@ async def reanalyze_event(
 
             frame_count_used = len(extracted_frames)
 
-            # Convert frames to base64 for multi-image analysis
+            # Convert frames to base64 for multi-image analysis. FrameExtractor
+            # returns JPEG-encoded bytes, but guard for numpy arrays too (the
+            # previous code assumed numpy and cv2.imencode'd the bytes -> error).
             frames_base64 = []
             for frame in extracted_frames:
-                _, buffer = cv2.imencode('.jpg', frame, [cv2.IMWRITE_JPEG_QUALITY, 85])
-                frames_base64.append(base64.b64encode(buffer).decode('utf-8'))
+                if isinstance(frame, (bytes, bytearray)):
+                    frames_base64.append(base64.b64encode(frame).decode('utf-8'))
+                else:
+                    _, buffer = cv2.imencode('.jpg', frame, [cv2.IMWRITE_JPEG_QUALITY, 85])
+                    frames_base64.append(base64.b64encode(buffer).decode('utf-8'))
 
             result = await ai_service.describe_images(
                 images_base64=frames_base64,

--- a/backend/app/services/protect_ai_pipeline.py
+++ b/backend/app/services/protect_ai_pipeline.py
@@ -178,11 +178,16 @@ class ProtectAIPipeline:
             from app.services.frame_extractor import get_frame_extractor
 
             extractor = get_frame_extractor()
-            # Use adaptive or uniform sampling based on camera settings if available
-            frames, timestamps = await extractor.extract_frames(
-                video_path=clip_path,
-                max_frames=5,           # Reasonable default for cost control
-                strategy="adaptive"     # Can be made configurable later
+            # Use extract_frames_with_timestamps (returns a (frames, timestamps)
+            # tuple). NOTE: plain extract_frames() returns only List[bytes] and
+            # takes clip_path/frame_count — the previous call used
+            # video_path=/max_frames= and unpacked two values, raising TypeError
+            # (caught below) so this returned [] and multi-frame silently
+            # degraded to single-frame even when a clip was available.
+            frames, timestamps = await extractor.extract_frames_with_timestamps(
+                clip_path=clip_path,
+                frame_count=5,                 # Reasonable default for cost control
+                sampling_strategy="adaptive",  # content-aware selection
             )
 
             # Convert to bytes if they come back as numpy arrays


### PR DESCRIPTION
## The core fix for "only single-frame analysis"
After the clip-download signature fix (#496), the **live pipeline still produced single-frame**. Second root cause: `ProtectAIPipeline._extract_frames_from_clip` called `extract_frames(video_path=, max_frames=, strategy=)` and unpacked `(frames, timestamps)`, but `FrameExtractor.extract_frames(clip_path, frame_count, strategy, filter_blur)` returns a single `List[bytes]`. The bad kwargs raised `TypeError`, swallowed by the surrounding `except` → returned `[]` → `if frames:` False → multi_frame skipped → **single_frame for every event with a clip**.

Fix: use `extract_frames_with_timestamps(clip_path, frame_count, sampling_strategy)` which returns the `(frames, timestamps)` tuple. `analyze_images(images: List[bytes])` already matches.

## Also: reanalyze multi-frame repair
The on-demand reanalyze multi_frame path had a parallel cascade (4 bugs total, with #497/#498): controller attr, clip service, `extract_frames` kwargs, and cv2-on-bytes base64. Second commit fixes the extraction + base64 there too.

Both root causes (clip download #496 + frame extraction here) are required for live multi-frame. Validation in thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)