### PR TITLE
fix(time): UTC timestamp storage + consistent local display

### DIFF
--- a/backend/alembic/versions/f3a2c1d4e5b6_fix_protect_event_local_timestamps.py
+++ b/backend/alembic/versions/f3a2c1d4e5b6_fix_protect_event_local_timestamps.py
@@ -1,0 +1,97 @@
+"""fix protect event timestamps stored in server-local time
+
+A refactor of ProtectMediaService (~2026-06-28 16:35 UTC) made
+``_retrieve_snapshot`` pass ``datetime.now()`` (server-LOCAL, US/Central) as the
+snapshot timestamp, which becomes ``Event.timestamp``. Every other timestamp in
+the app (``created_at``, RTSP/USB events) is UTC, so these Protect events were
+stored 5–6 hours off and rendered inconsistently in the UI.
+
+The code is fixed forward (``datetime.now(timezone.utc)``). This migration repairs
+the rows already written with a local timestamp.
+
+Selection is deliberately narrow and self-validating so it can never touch
+correctly-stored rows or be applied twice:
+  * source_type = 'protect'                       (only path with the bug)
+  * created_at >= 2026-06-28                       (the regression window)
+  * 4h < (created_at - timestamp) < 7h            (a US/Central tz offset, not a
+                                                    seconds-level normal gap nor a
+                                                    multi-day backfill gap)
+
+Conversion uses DST-aware zoneinfo localisation (America/Chicago -> UTC), so it is
+correct for both CDT (-5) and CST (-6). After conversion the gap collapses to ~0,
+so a re-run selects nothing (idempotent).
+
+Revision ID: f3a2c1d4e5b6
+Revises: e7c9a1b3d5f2
+Create Date: 2026-06-29
+"""
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "f3a2c1d4e5b6"
+down_revision = "e7c9a1b3d5f2"
+branch_labels = None
+depends_on = None
+
+_SERVER_TZ = ZoneInfo("America/Chicago")
+
+# Rows whose stored `timestamp` is server-local instead of UTC. The gap bounds
+# (in days, for julianday math) target a tz offset specifically: 4h..7h.
+_SELECT = sa.text(
+    """
+    SELECT id, timestamp
+    FROM events
+    WHERE source_type = 'protect'
+      AND created_at >= '2026-06-28'
+      AND (julianday(created_at) - julianday(timestamp)) BETWEEN (4.0/24.0) AND (7.0/24.0)
+    """
+)
+
+
+def _parse(ts):
+    """Parse a stored naive datetime string/obj into a naive datetime."""
+    if isinstance(ts, datetime):
+        return ts
+    s = str(ts)
+    # SQLite stores 'YYYY-MM-DD HH:MM:SS[.ffffff]'
+    for fmt in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"):
+        try:
+            return datetime.strptime(s, fmt)
+        except ValueError:
+            continue
+    # Last resort: ISO-ish
+    return datetime.fromisoformat(s.replace("Z", ""))
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    rows = bind.execute(_SELECT).fetchall()
+    if not rows:
+        return
+
+    update = sa.text("UPDATE events SET timestamp = :ts WHERE id = :id")
+    fixed = 0
+    for row in rows:
+        local_naive = _parse(row.timestamp)
+        # Interpret the stored value as server-local, convert to UTC, store naive
+        # UTC to match the rest of the schema.
+        utc_naive = (
+            local_naive.replace(tzinfo=_SERVER_TZ)
+            .astimezone(timezone.utc)
+            .replace(tzinfo=None)
+        )
+        bind.execute(update, {"ts": utc_naive, "id": row.id})
+        fixed += 1
+
+    print(f"[f3a2c1d4e5b6] Converted {fixed} protect event timestamp(s) local -> UTC")
+
+
+def downgrade() -> None:
+    # No-op: reversing would re-introduce incorrect local timestamps. The forward
+    # data is correct UTC; there is nothing safe to undo.
+    pass

--- a/backend/app/services/protect_media_service.py
+++ b/backend/app/services/protect_media_service.py
@@ -16,7 +16,7 @@ Extracted from ProtectEventHandler during Phase 4 decomposition.
 """
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -120,7 +120,11 @@ class ProtectMediaService:
                 protect_camera_id=protect_camera_id,
                 camera_id=camera_id,
                 camera_name=camera_name,
-                timestamp=datetime.now(),
+                # MUST be UTC: this becomes Event.timestamp. datetime.now() is
+                # local (server is US/Central), which stored event timestamps 5h
+                # off from the UTC convention used everywhere else (created_at,
+                # RTSP/USB events), causing the timezone display discrepancy.
+                timestamp=datetime.now(timezone.utc),
             )
             return result
         except Exception as e:

--- a/frontend/app/status/page.tsx
+++ b/frontend/app/status/page.tsx
@@ -24,7 +24,7 @@ import {
   RotateCcw,
   Shield,
 } from 'lucide-react';
-import { formatDistanceToNow } from 'date-fns';
+import { parseApiDate, formatRelative } from '@/lib/datetime';
 
 import { apiClient } from '@/lib/api-client';
 import type { SystemHealth, LogEntry, LogsResponse } from '@/types/monitoring';
@@ -298,7 +298,7 @@ export default function StatusPage() {
                 Real-time protection status for vision providers
                 {lastCircuitBreakerReset && (
                   <span className="text-[10px] text-muted-foreground">
-                    · Last reset {formatDistanceToNow(new Date(lastCircuitBreakerReset), { addSuffix: true })}
+                    · Last reset {formatRelative(lastCircuitBreakerReset)}
                   </span>
                 )}
               </CardDescription>
@@ -497,7 +497,7 @@ export default function StatusPage() {
                 {logs.map((log, index) => (
                   <div key={index} className="flex gap-2 border-b border-muted pb-1 last:border-0">
                     <span className="shrink-0 text-muted-foreground">
-                      {new Date(log.timestamp).toLocaleTimeString()}
+                      {parseApiDate(log.timestamp)!.toLocaleTimeString()}
                     </span>
                     <span className={`shrink-0 w-16 ${getLogLevelColor(log.level)}`}>
                       [{log.level}]

--- a/frontend/components/cameras/CameraPreview.tsx
+++ b/frontend/components/cameras/CameraPreview.tsx
@@ -15,7 +15,7 @@ import { Button } from '@/components/ui/button';
 import { CameraStatus } from './CameraStatus';
 import { LiveStreamModal } from '@/components/streaming/LiveStreamModal';
 import type { ICamera, CameraSourceType } from '@/types/camera';
-import { format } from 'date-fns';
+import { formatDateTime } from '@/lib/datetime';
 
 interface CameraPreviewProps {
   /**
@@ -144,7 +144,7 @@ export const CameraPreview = memo(function CameraPreview({ camera, onDelete }: C
 
         {/* Updated timestamp */}
         <div className="text-xs text-muted-foreground">
-          Updated: {format(new Date(camera.updated_at), 'MMM d, yyyy h:mm a')}
+          Updated: {formatDateTime(camera.updated_at)}
         </div>
 
         {/* Action buttons */}

--- a/frontend/components/dashboard/PackageDeliveryWidget.tsx
+++ b/frontend/components/dashboard/PackageDeliveryWidget.tsx
@@ -21,14 +21,7 @@ import { apiClient } from '@/lib/api-client';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { CARRIER_CONFIG } from '@/types/event';
-
-// Parse timestamp as UTC (backend stores UTC without timezone indicator)
-function parseUTCTimestamp(timestamp: string): Date {
-  const ts = timestamp.includes('Z') || timestamp.includes('+') || timestamp.includes('-', 10)
-    ? timestamp
-    : timestamp.replace(' ', 'T') + 'Z';
-  return new Date(ts);
-}
+import { parseApiDate } from '@/lib/datetime';
 
 /**
  * Carrier badge component with color coding
@@ -211,7 +204,7 @@ export function PackageDeliveryWidget() {
                 >
                   <CarrierBadge carrier={event.delivery_carrier} />
                   <span className="text-muted-foreground">
-                    {formatDistanceToNow(parseUTCTimestamp(event.timestamp), { addSuffix: true })}
+                    {formatDistanceToNow(parseApiDate(event.timestamp)!, { addSuffix: true })}
                   </span>
                   <span className="text-muted-foreground truncate">
                     {event.camera_name}

--- a/frontend/components/dashboard/RecentActivity.tsx
+++ b/frontend/components/dashboard/RecentActivity.tsx
@@ -13,14 +13,7 @@ import { Activity, ArrowRight, Camera, Clock, AlertCircle } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import Link from 'next/link';
 import { getConfidenceColor } from '@/types/event';
-
-// Parse timestamp as UTC (backend stores UTC without timezone indicator)
-function parseUTCTimestamp(timestamp: string): Date {
-  const ts = timestamp.includes('Z') || timestamp.includes('+') || timestamp.includes('-', 10)
-    ? timestamp
-    : timestamp.replace(' ', 'T') + 'Z';
-  return new Date(ts);
-}
+import { parseApiDate } from '@/lib/datetime';
 
 export function RecentActivity() {
   const { data, isLoading, error } = useRecentEvents(5);
@@ -130,7 +123,7 @@ export function RecentActivity() {
                   <div className="flex items-center gap-2 text-xs text-muted-foreground mt-1">
                     <span className="flex items-center">
                       <Clock className="h-3 w-3 mr-1" />
-                      {formatDistanceToNow(parseUTCTimestamp(event.timestamp), { addSuffix: true })}
+                      {formatDistanceToNow(parseApiDate(event.timestamp)!, { addSuffix: true })}
                     </span>
                     {event.objects_detected?.length > 0 && (
                       <span className="flex items-center gap-1">

--- a/frontend/components/entities/EntityAlertRules.tsx
+++ b/frontend/components/entities/EntityAlertRules.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
-import { formatDistanceToNow } from 'date-fns';
+import { formatRelative } from '@/lib/datetime';
 import { Bell, BellOff, Clock, AlertTriangle } from 'lucide-react';
 import Link from 'next/link';
 
@@ -88,7 +88,7 @@ export function EntityAlertRules({ entityId }: EntityAlertRulesProps) {
             </Badge>
             {rule.last_triggered_at && (
               <span className="text-xs text-muted-foreground hidden sm:inline">
-                {formatDistanceToNow(new Date(rule.last_triggered_at), { addSuffix: true })}
+                {formatRelative(rule.last_triggered_at)}
               </span>
             )}
           </div>

--- a/frontend/components/entities/EntityCard.tsx
+++ b/frontend/components/entities/EntityCard.tsx
@@ -24,6 +24,7 @@ import { cn } from '@/lib/utils';
 import { EntityAlertModal } from './EntityAlertModal';
 import { EntityEditModal, type EntityEditData } from './EntityEditModal';
 import type { IEntity } from '@/types/entity';
+import { parseApiDate } from '@/lib/datetime';
 
 interface EntityCardProps {
   entity: IEntity;
@@ -68,14 +69,6 @@ function getEntityTypeBadgeVariant(entityType: string): 'default' | 'secondary' 
     default:
       return 'outline';
   }
-}
-
-// Parse timestamp as UTC
-function parseUTCTimestamp(timestamp: string): Date {
-  const ts = timestamp.includes('Z') || timestamp.includes('+') || timestamp.includes('-', 10)
-    ? timestamp
-    : timestamp.replace(' ', 'T') + 'Z';
-  return new Date(ts);
 }
 
 export const EntityCard = memo(function EntityCard({
@@ -123,8 +116,8 @@ export const EntityCard = memo(function EntityCard({
       : `${apiUrl}${thumbnailUrl}`
     : null;
 
-  const firstSeenDate = parseUTCTimestamp(entity.first_seen_at);
-  const lastSeenDate = parseUTCTimestamp(entity.last_seen_at);
+  const firstSeenDate = parseApiDate(entity.first_seen_at)!;
+  const lastSeenDate = parseApiDate(entity.last_seen_at)!;
   const lastSeenRelative = formatDistanceToNow(lastSeenDate, { addSuffix: true });
 
   // Display name with fallback

--- a/frontend/components/entities/EntityDetail.tsx
+++ b/frontend/components/entities/EntityDetail.tsx
@@ -39,6 +39,7 @@ import { EntityAlertRules } from './EntityAlertRules';
 import { cn } from '@/lib/utils';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type { IEntity } from '@/types/entity';
+import { parseApiDate } from '@/lib/datetime';
 
 interface EntityDetailProps {
   /** The entity to display (basic info from list) */
@@ -49,14 +50,6 @@ interface EntityDetailProps {
   onClose: () => void;
   /** Callback when delete is requested */
   onDelete: (entity: IEntity) => void;
-}
-
-// Parse timestamp as UTC
-function parseUTCTimestamp(timestamp: string): Date {
-  const ts = timestamp.includes('Z') || timestamp.includes('+') || timestamp.includes('-', 10)
-    ? timestamp
-    : timestamp.replace(' ', 'T') + 'Z';
-  return new Date(ts);
 }
 
 /**
@@ -234,11 +227,11 @@ export function EntityDetail({
                     </p>
                     <p>
                       First seen:{' '}
-                      {parseUTCTimestamp(entityDetail.first_seen_at).toLocaleDateString()}
+                      {parseApiDate(entityDetail.first_seen_at)!.toLocaleDateString()}
                     </p>
                     <p>
                       Last seen:{' '}
-                      {formatDistanceToNow(parseUTCTimestamp(entityDetail.last_seen_at), {
+                      {formatDistanceToNow(parseApiDate(entityDetail.last_seen_at)!, {
                         addSuffix: true,
                       })}
                     </p>

--- a/frontend/components/entities/EntityEventList.tsx
+++ b/frontend/components/entities/EntityEventList.tsx
@@ -37,6 +37,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { useEntityEvents, useUnlinkEvent } from '@/hooks/useEntities';
 import type { IEvent } from '@/types/event';
+import { parseApiDate } from '@/lib/datetime';
 
 // P15-1.2: Threshold for enabling virtual scrolling
 const VIRTUAL_SCROLL_THRESHOLD = 50;
@@ -47,14 +48,6 @@ interface EntityEventListProps {
   entityId: string;
   /** Optional callback when event is clicked - P15-1.3: now passes full event data */
   onEventClick?: (eventId: string, event?: IEvent) => void;
-}
-
-// Parse timestamp as UTC
-function parseUTCTimestamp(timestamp: string): Date {
-  const ts = timestamp.includes('Z') || timestamp.includes('+') || timestamp.includes('-', 10)
-    ? timestamp
-    : timestamp.replace(' ', 'T') + 'Z';
-  return new Date(ts);
 }
 
 /**
@@ -215,7 +208,7 @@ export function EntityEventList({ entityId, onEventClick }: EntityEventListProps
         ? event.thumbnail_url
         : `${apiUrl}${event.thumbnail_url}`
       : null;
-    const eventDate = parseUTCTimestamp(event.timestamp);
+    const eventDate = parseApiDate(event.timestamp)!;
 
     return (
       <div

--- a/frontend/components/events/DoorbellEventCard.tsx
+++ b/frontend/components/events/DoorbellEventCard.tsx
@@ -16,6 +16,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { Bell, Video, ChevronDown, ChevronUp } from 'lucide-react';
 import type { IEvent } from '@/types/event';
 import { Card } from '@/components/ui/card';
+import { parseApiDate } from '@/lib/datetime';
 
 interface DoorbellEventCardProps {
   event: IEvent;
@@ -29,14 +30,6 @@ const OBJECT_ICONS: Record<string, string> = {
   package: '📦',
   unknown: '❓',
 };
-
-// Parse timestamp as UTC (backend stores UTC without timezone indicator)
-function parseUTCTimestamp(timestamp: string): Date {
-  const ts = timestamp.includes('Z') || timestamp.includes('+') || timestamp.includes('-', 10)
-    ? timestamp
-    : timestamp.replace(' ', 'T') + 'Z';
-  return new Date(ts);
-}
 
 // Format relative time with "Just now" for very recent events
 function formatRelativeTime(date: Date): string {
@@ -57,7 +50,7 @@ export const DoorbellEventCard = memo(function DoorbellEventCard({
   const [isExpanded, setIsExpanded] = useState(false);
   const [imageError, setImageError] = useState(false);
 
-  const eventDate = parseUTCTimestamp(event.timestamp);
+  const eventDate = parseApiDate(event.timestamp)!;
   const relativeTime = formatRelativeTime(eventDate);
 
   // Determine thumbnail source

--- a/frontend/components/events/EventCard.tsx
+++ b/frontend/components/events/EventCard.tsx
@@ -30,6 +30,7 @@ import { EntitySelectModal } from '@/components/entities/EntitySelectModal';
 import { EntityCreateModal } from '@/components/entities/EntityCreateModal';
 import { useAssignEventToEntity } from '@/hooks/useEntities';
 import { cn } from '@/lib/utils';
+import { parseApiDate } from '@/lib/datetime';
 
 interface EventCardProps {
   event: IEvent;
@@ -49,15 +50,6 @@ const OBJECT_ICONS: Record<string, string> = {
   package: '📦',
   unknown: '❓',
 };
-
-// Parse timestamp as UTC (backend stores UTC without timezone indicator)
-function parseUTCTimestamp(timestamp: string): Date {
-  // If timestamp doesn't have timezone info, append 'Z' to interpret as UTC
-  const ts = timestamp.includes('Z') || timestamp.includes('+') || timestamp.includes('-', 10)
-    ? timestamp
-    : timestamp.replace(' ', 'T') + 'Z';
-  return new Date(ts);
-}
 
 export const EventCard = memo(function EventCard({
   event,
@@ -156,7 +148,7 @@ export const EventCard = memo(function EventCard({
   // Story P9-4.4: Check if event has entity association
   const hasEntity = !!event.entity_id;
 
-  const eventDate = parseUTCTimestamp(event.timestamp);
+  const eventDate = parseApiDate(event.timestamp)!;
   const relativeTime = formatDistanceToNow(eventDate, {
     addSuffix: true,
   });

--- a/frontend/components/events/EventDetailModal.tsx
+++ b/frontend/components/events/EventDetailModal.tsx
@@ -54,15 +54,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { AnnotationLegend } from './AnnotationLegend';
-
-// Parse timestamp as UTC (backend stores UTC without timezone indicator)
-function parseUTCTimestamp(timestamp: string): Date {
-  // If timestamp doesn't have timezone info, append 'Z' to interpret as UTC
-  const ts = timestamp.includes('Z') || timestamp.includes('+') || timestamp.includes('-', 10)
-    ? timestamp
-    : timestamp.replace(' ', 'T') + 'Z';
-  return new Date(ts);
-}
+import { parseApiDate } from '@/lib/datetime';
 
 interface EventDetailModalProps {
   event: IEvent | null;
@@ -153,7 +145,7 @@ export function EventDetailModal({
     }
   };
 
-  const eventDate = parseUTCTimestamp(event.timestamp);
+  const eventDate = parseApiDate(event.timestamp)!;
   const relativeTime = formatDistanceToNow(eventDate, {
     addSuffix: true,
   });
@@ -456,7 +448,7 @@ export function EventDetailModal({
 
               <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
                 {event.correlated_events.map((relatedEvent) => {
-                  const relatedDate = parseUTCTimestamp(relatedEvent.timestamp);
+                  const relatedDate = parseApiDate(relatedEvent.timestamp)!;
                   const relatedRelativeTime = formatDistanceToNow(relatedDate, { addSuffix: true });
 
                   // Build full thumbnail URL

--- a/frontend/components/events/FeedbackButtons.tsx
+++ b/frontend/components/events/FeedbackButtons.tsx
@@ -40,6 +40,7 @@ import { toast } from 'sonner';
 import { useSubmitFeedback, useUpdateFeedback, useDeleteFeedback } from '@/hooks/useFeedback';
 import type { IEventFeedback } from '@/types/event';
 import { cn } from '@/lib/utils';
+import { parseApiDate } from '@/lib/datetime';
 
 interface FeedbackButtonsProps {
   /** Event UUID to submit feedback for */
@@ -93,7 +94,7 @@ export const FeedbackButtons = memo(function FeedbackButtons({
   const editedTooltip = useMemo(() => {
     if (!wasEdited || !updatedAt) return null;
     try {
-      const date = new Date(updatedAt);
+      const date = parseApiDate(updatedAt)!;
       return `Edited on ${date.toLocaleDateString()} at ${date.toLocaleTimeString()}`;
     } catch {
       return 'Edited';

--- a/frontend/components/events/ReanalyzedIndicator.tsx
+++ b/frontend/components/events/ReanalyzedIndicator.tsx
@@ -14,20 +14,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { parseApiDate } from '@/lib/datetime';
 
 interface ReanalyzedIndicatorProps {
   /** Timestamp when event was re-analyzed (ISO 8601), null if never re-analyzed */
   reanalyzedAt?: string | null;
-}
-
-/**
- * Parse timestamp as UTC
- */
-function parseUTCTimestamp(timestamp: string): Date {
-  const ts = timestamp.includes('Z') || timestamp.includes('+') || timestamp.includes('-', 10)
-    ? timestamp
-    : timestamp.replace(' ', 'T') + 'Z';
-  return new Date(ts);
 }
 
 /**
@@ -42,7 +33,7 @@ export function ReanalyzedIndicator({ reanalyzedAt }: ReanalyzedIndicatorProps) 
     return null;
   }
 
-  const reanalyzedDate = parseUTCTimestamp(reanalyzedAt);
+  const reanalyzedDate = parseApiDate(reanalyzedAt)!;
   const relativeTime = formatDistanceToNow(reanalyzedDate, { addSuffix: true });
 
   return (

--- a/frontend/components/notifications/NotificationDropdown.tsx
+++ b/frontend/components/notifications/NotificationDropdown.tsx
@@ -11,7 +11,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { formatDistanceToNow } from 'date-fns';
+import { parseApiDate, formatRelative } from '@/lib/datetime';
 import { Check, Trash2, Loader2, Bell } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -99,7 +99,7 @@ export function NotificationDropdown({ onClose }: NotificationDropdownProps) {
                 if (a.is_doorbell_ring && !b.is_doorbell_ring) return -1;
                 if (!a.is_doorbell_ring && b.is_doorbell_ring) return 1;
                 // Then by created_at (newest first)
-                return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+                return parseApiDate(b.created_at)!.getTime() - parseApiDate(a.created_at)!.getTime();
               })
               .map((notification) => (
                 <NotificationItem
@@ -144,9 +144,7 @@ function NotificationItem({ notification, onClick, onDelete }: NotificationItemP
   const isDoorbellRing = notification.is_doorbell_ring;
 
   // Format relative timestamp
-  const timeAgo = formatDistanceToNow(new Date(notification.created_at), {
-    addSuffix: true,
-  });
+  const timeAgo = formatRelative(notification.created_at);
 
   // Build thumbnail URL
   const thumbnailUrl = notification.thumbnail_url

--- a/frontend/components/rules/RuleTestResults.tsx
+++ b/frontend/components/rules/RuleTestResults.tsx
@@ -6,14 +6,7 @@ import { FlaskConical, CheckCircle, AlertCircle, Loader2 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 
 import { apiClient, ApiError } from '@/lib/api-client';
-
-// Parse timestamp as UTC (backend stores UTC without timezone indicator)
-function parseUTCTimestamp(timestamp: string): Date {
-  const ts = timestamp.includes('Z') || timestamp.includes('+') || timestamp.includes('-', 10)
-    ? timestamp
-    : timestamp.replace(' ', 'T') + 'Z';
-  return new Date(ts);
-}
+import { parseApiDate } from '@/lib/datetime';
 import type { IAlertRuleTestResponse } from '@/types/alert-rule';
 import type { IEvent } from '@/types/event';
 import { Button } from '@/components/ui/button';
@@ -129,7 +122,7 @@ export function RuleTestResults({ ruleId }: RuleTestResultsProps) {
                         <div className="flex-1 min-w-0">
                           <p className="text-sm break-words">{event.description || 'No description'}</p>
                           <p className="text-xs text-muted-foreground">
-                            {formatDistanceToNow(parseUTCTimestamp(event.timestamp), { addSuffix: true })}
+                            {formatDistanceToNow(parseApiDate(event.timestamp)!, { addSuffix: true })}
                           </p>
                         </div>
                         <div className="flex items-center gap-2 ml-2">

--- a/frontend/components/rules/RulesList.tsx
+++ b/frontend/components/rules/RulesList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { formatDistanceToNow } from 'date-fns';
+import { formatRelative } from '@/lib/datetime';
 import { Bell, Plus, Pencil, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -176,7 +176,7 @@ interface RuleRowProps {
 function RuleRow({ rule, onToggleEnabled, onEdit, onDelete, isToggling }: RuleRowProps) {
   // Format last triggered time
   const lastTriggeredText = rule.last_triggered_at
-    ? formatDistanceToNow(new Date(rule.last_triggered_at), { addSuffix: true })
+    ? formatRelative(rule.last_triggered_at)
     : 'Never';
 
   // Get action badges

--- a/frontend/components/rules/WebhookLogs.tsx
+++ b/frontend/components/rules/WebhookLogs.tsx
@@ -7,7 +7,8 @@
 
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { formatDistanceToNow, format } from 'date-fns';
+import { format } from 'date-fns';
+import { formatRelative, formatDateTime } from '@/lib/datetime';
 import {
   Download,
   RefreshCw,
@@ -361,7 +362,7 @@ interface WebhookLogRowProps {
 }
 
 function WebhookLogRow({ log, showRule, compact, onClick }: WebhookLogRowProps) {
-  const timeAgo = formatDistanceToNow(new Date(log.created_at), { addSuffix: true });
+  const timeAgo = formatRelative(log.created_at);
 
   return (
     <tr
@@ -372,7 +373,7 @@ function WebhookLogRow({ log, showRule, compact, onClick }: WebhookLogRowProps) 
       <td className="p-3">
         <div className="text-sm">{timeAgo}</div>
         <div className="text-xs text-muted-foreground">
-          {format(new Date(log.created_at), 'HH:mm:ss')}
+          {formatDateTime(log.created_at, 'HH:mm:ss')}
         </div>
       </td>
 
@@ -470,7 +471,7 @@ function WebhookLogDetailDialog({ log, open, onClose }: WebhookLogDetailDialogPr
           <div className="flex items-center justify-between">
             <span className="text-sm font-medium">Timestamp</span>
             <span className="text-sm text-muted-foreground">
-              {format(new Date(log.created_at), 'PPpp')}
+              {formatDateTime(log.created_at, 'PPpp')}
             </span>
           </div>
 

--- a/frontend/components/settings/AIResilienceSettings.tsx
+++ b/frontend/components/settings/AIResilienceSettings.tsx
@@ -9,7 +9,7 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { toast } from 'sonner';
 import { Loader2, RefreshCw, Save, RotateCcw } from 'lucide-react';
-import { formatDistanceToNow } from 'date-fns';
+import { formatRelative } from '@/lib/datetime';
 
 interface CircuitBreakerConfig {
   failure_threshold: number;
@@ -325,7 +325,7 @@ export function AIResilienceSettings() {
             Configure circuit breaker behavior for each AI provider. Changes take effect immediately after saving.
             {lastReset && (
               <span className="ml-2 text-xs text-muted-foreground">
-                Last reset: {formatDistanceToNow(new Date(lastReset), { addSuffix: true })}
+                Last reset: {formatRelative(lastReset)}
               </span>
             )}
           </p>

--- a/frontend/components/settings/APIKeySettings.tsx
+++ b/frontend/components/settings/APIKeySettings.tsx
@@ -12,7 +12,7 @@
 
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { formatDistanceToNow, format } from 'date-fns';
+import { formatRelative, formatDateTime } from '@/lib/datetime';
 import {
   Key,
   Plus,
@@ -260,13 +260,13 @@ export function APIKeySettings() {
                       <ScopesBadges scopes={apiKey.scopes} />
                     </div>
                     <div className="text-xs text-muted-foreground">
-                      <span>Created {formatDistanceToNow(new Date(apiKey.created_at), { addSuffix: true })}</span>
+                      <span>Created {formatRelative(apiKey.created_at)}</span>
                       {apiKey.last_used_at && (
-                        <span> • Last used {formatDistanceToNow(new Date(apiKey.last_used_at), { addSuffix: true })}</span>
+                        <span> • Last used {formatRelative(apiKey.last_used_at)}</span>
                       )}
                       <span> • {apiKey.usage_count} requests</span>
                       {apiKey.expires_at && (
-                        <span> • Expires {format(new Date(apiKey.expires_at), 'MMM d, yyyy')}</span>
+                        <span> • Expires {formatDateTime(apiKey.expires_at, 'MMM d, yyyy')}</span>
                       )}
                     </div>
                   </div>
@@ -436,7 +436,7 @@ export function APIKeySettings() {
               <p><strong>Scopes:</strong> {newKeyResult?.scopes.join(', ')}</p>
               <p><strong>Rate Limit:</strong> {newKeyResult?.rate_limit_per_minute} requests/minute</p>
               {newKeyResult?.expires_at && (
-                <p><strong>Expires:</strong> {format(new Date(newKeyResult.expires_at), 'MMM d, yyyy')}</p>
+                <p><strong>Expires:</strong> {formatDateTime(newKeyResult.expires_at, 'MMM d, yyyy')}</p>
               )}
             </div>
           </div>

--- a/frontend/components/settings/BackupRestore.tsx
+++ b/frontend/components/settings/BackupRestore.tsx
@@ -30,6 +30,7 @@ import {
 } from 'lucide-react';
 
 import { apiClient, ApiError } from '@/lib/api-client';
+import { parseApiDate } from '@/lib/datetime';
 import type { IBackupListItem, IValidationResponse, IBackupOptions, IRestoreOptions } from '@/types/backup';
 
 import { Button } from '@/components/ui/button';
@@ -58,7 +59,7 @@ function formatBytes(bytes: number): string {
 }
 
 function formatDate(isoString: string): string {
-  const date = new Date(isoString);
+  const date = parseApiDate(isoString)!;
   return date.toLocaleString(undefined, {
     year: 'numeric',
     month: 'short',

--- a/frontend/components/settings/CostDashboard.tsx
+++ b/frontend/components/settings/CostDashboard.tsx
@@ -14,6 +14,7 @@
 import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { format, subDays, startOfMonth } from 'date-fns';
+import { formatDateTime } from '@/lib/datetime';
 import {
   PieChart,
   Pie,
@@ -399,8 +400,8 @@ export function CostDashboard() {
           <p className="text-sm text-muted-foreground">
             {usageData?.period && (
               <>
-                {format(new Date(usageData.period.start), 'MMM d, yyyy')} -{' '}
-                {format(new Date(usageData.period.end), 'MMM d, yyyy')}
+                {formatDateTime(usageData.period.start, 'MMM d, yyyy')} -{' '}
+                {formatDateTime(usageData.period.end, 'MMM d, yyyy')}
               </>
             )}
           </p>
@@ -599,13 +600,13 @@ export function CostDashboard() {
                 </defs>
                 <XAxis
                   dataKey="date"
-                  tickFormatter={(date) => format(new Date(date as string), 'MMM d')}
+                  tickFormatter={(date) => formatDateTime(date as string, 'MMM d')}
                   tick={{ fontSize: 12 }}
                 />
                 <YAxis tickFormatter={(v) => formatCost(v)} tick={{ fontSize: 12 }} />
                 <Tooltip
                   content={<ChartTooltip />}
-                  labelFormatter={(date) => format(new Date(date as string), 'MMMM d, yyyy')}
+                  labelFormatter={(date) => formatDateTime(date as string, 'MMMM d, yyyy')}
                 />
                 <Area
                   type="monotone"

--- a/frontend/components/settings/DeviceManager.tsx
+++ b/frontend/components/settings/DeviceManager.tsx
@@ -12,7 +12,7 @@
 
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { formatDistanceToNow } from 'date-fns';
+import { formatRelative } from '@/lib/datetime';
 import {
   Smartphone,
   Trash2,
@@ -243,7 +243,7 @@ export function DeviceManager() {
                       {device.last_seen_at && (
                         <>
                           {' • Last seen '}
-                          {formatDistanceToNow(new Date(device.last_seen_at), { addSuffix: true })}
+                          {formatRelative(device.last_seen_at)}
                         </>
                       )}
                     </div>

--- a/frontend/components/settings/HomeKitDiagnostics.tsx
+++ b/frontend/components/settings/HomeKitDiagnostics.tsx
@@ -14,7 +14,7 @@
  * - Test event trigger button (P7-1.3 AC5)
  */
 import React, { useState } from 'react';
-import { formatDistanceToNow } from 'date-fns';
+import { parseApiDate, formatRelative } from '@/lib/datetime';
 import {
   useHomekitDiagnostics,
   useHomekitTestConnectivity,
@@ -80,7 +80,7 @@ const levelColors: Record<string, string> = {
 };
 
 function formatTimestamp(timestamp: string): string {
-  const date = new Date(timestamp);
+  const date = parseApiDate(timestamp)!;
   return date.toLocaleTimeString('en-US', {
     hour: '2-digit',
     minute: '2-digit',
@@ -290,7 +290,7 @@ function ConnectivityTestPanel() {
  */
 function formatRelativeTime(timestamp: string): string {
   try {
-    return formatDistanceToNow(new Date(timestamp), { addSuffix: true });
+    return formatRelative(timestamp);
   } catch {
     return 'Unknown';
   }

--- a/frontend/components/settings/LogViewer.tsx
+++ b/frontend/components/settings/LogViewer.tsx
@@ -8,6 +8,7 @@
 import { useState, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { format } from 'date-fns';
+import { parseApiDate } from '@/lib/datetime';
 import {
   Search,
   Download,
@@ -56,9 +57,9 @@ function LogEntryRow({ entry, isExpanded, onToggle }: LogEntryRowProps) {
   let timestamp = '--';
   if (entry.timestamp) {
     try {
-      const date = new Date(entry.timestamp);
+      const date = parseApiDate(entry.timestamp);
       // Check if date is valid (Invalid Date has NaN for getTime())
-      if (!isNaN(date.getTime())) {
+      if (date && !isNaN(date.getTime())) {
         timestamp = format(date, 'HH:mm:ss.SSS');
       }
     } catch {

--- a/frontend/components/settings/PairingConfirmation.tsx
+++ b/frontend/components/settings/PairingConfirmation.tsx
@@ -9,7 +9,7 @@
 
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { formatDistanceToNow } from 'date-fns';
+import { formatRelative } from '@/lib/datetime';
 import { Smartphone, Check, Loader2, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -146,7 +146,7 @@ export function PairingConfirmation() {
                       {pairing.device_name || pairing.device_model || `${pairing.platform} device`}
                     </p>
                     <p className="text-xs text-muted-foreground">
-                      Expires {formatDistanceToNow(new Date(pairing.expires_at), { addSuffix: true })}
+                      Expires {formatRelative(pairing.expires_at)}
                     </p>
                   </div>
                 </div>

--- a/frontend/components/settings/SessionManagement.tsx
+++ b/frontend/components/settings/SessionManagement.tsx
@@ -28,6 +28,7 @@ import {
 } from 'lucide-react';
 
 import { apiClient } from '@/lib/api-client';
+import { parseApiDate, formatLocale } from '@/lib/datetime';
 import type { ISession } from '@/types/auth';
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -63,7 +64,7 @@ function getDeviceIcon(deviceInfo: string | null) {
 }
 
 function formatRelativeTime(dateString: string): string {
-  const date = new Date(dateString);
+  const date = parseApiDate(dateString)!;
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
   const diffMins = Math.floor(diffMs / (1000 * 60));
@@ -220,7 +221,7 @@ export function SessionManagement() {
                             {formatRelativeTime(session.last_active_at)}
                           </TooltipTrigger>
                           <TooltipContent>
-                            Last active: {new Date(session.last_active_at).toLocaleString()}
+                            Last active: {formatLocale(session.last_active_at)}
                           </TooltipContent>
                         </Tooltip>
                       </TooltipProvider>

--- a/frontend/components/settings/TunnelSettings.tsx
+++ b/frontend/components/settings/TunnelSettings.tsx
@@ -29,6 +29,7 @@ import {
 } from 'lucide-react';
 
 import { apiClient } from '@/lib/api-client';
+import { parseApiDate } from '@/lib/datetime';
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -54,7 +55,7 @@ function formatUptime(seconds: number): string {
  */
 function formatLastConnected(isoDate: string | null): string {
   if (!isoDate) return 'Never';
-  const date = new Date(isoDate);
+  const date = parseApiDate(isoDate)!;
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
   const diffMins = Math.floor(diffMs / 60000);

--- a/frontend/components/settings/UserManagement.tsx
+++ b/frontend/components/settings/UserManagement.tsx
@@ -31,6 +31,7 @@ import {
 } from 'lucide-react';
 
 import { apiClient } from '@/lib/api-client';
+import { formatLocale } from '@/lib/datetime';
 import type { IUser, IUserCreate, IUserCreateResponse, UserRole } from '@/types/auth';
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -246,7 +247,7 @@ export function UserManagement({ currentUserId }: UserManagementProps) {
 
   const formatDate = (dateString: string | null) => {
     if (!dateString) return 'Never';
-    return new Date(dateString).toLocaleString();
+    return formatLocale(dateString);
   };
 
   if (isLoading) {

--- a/frontend/components/summaries/GenerateSummaryDialog.tsx
+++ b/frontend/components/summaries/GenerateSummaryDialog.tsx
@@ -17,6 +17,7 @@
 
 import { useState, useCallback } from 'react';
 import { format, subHours } from 'date-fns';
+import { parseApiDate } from '@/lib/datetime';
 import {
   Sparkles,
   Clock,
@@ -93,8 +94,8 @@ function StatItem({
  * SummaryResult - Display generated summary (AC11)
  */
 function SummaryResult({ summary }: { summary: SummaryGenerateResponse }) {
-  const periodStart = new Date(summary.period_start);
-  const periodEnd = new Date(summary.period_end);
+  const periodStart = parseApiDate(summary.period_start)!;
+  const periodEnd = parseApiDate(summary.period_end)!;
 
   return (
     <div className="space-y-4">

--- a/frontend/components/video/VideoPlayerModal.tsx
+++ b/frontend/components/video/VideoPlayerModal.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Download, Play, Pause, Volume2, VolumeX, Maximize, Loader2 } from 'lucide-react';
+import { formatLocale } from '@/lib/datetime';
 
 interface VideoPlayerModalProps {
   open: boolean;
@@ -97,7 +98,7 @@ export function VideoPlayerModal({
   };
 
   const formattedTimestamp = timestamp
-    ? new Date(timestamp).toLocaleString()
+    ? formatLocale(timestamp)
     : undefined;
 
   return (

--- a/frontend/lib/datetime.ts
+++ b/frontend/lib/datetime.ts
@@ -1,0 +1,95 @@
+/**
+ * Centralized timestamp handling — the single source of truth for turning
+ * backend timestamps into `Date` objects for display.
+ *
+ * Backend contract: ALL timestamps are UTC. However, the API is backed by
+ * SQLite, whose `DateTime` columns serialize WITHOUT a timezone marker
+ * (e.g. `"2026-06-29T09:08:20"` rather than `"...Z"`). The browser's
+ * `new Date("2026-06-29T09:08:20")` interprets a naive datetime as *local*
+ * time, which renders UTC values shifted by the viewer's offset. Different
+ * components historically disagreed (some appended `Z`, most didn't), which is
+ * exactly the "discrepancy between areas" users saw.
+ *
+ * `parseApiDate` forces the correct interpretation; the `format*` helpers then
+ * render in the browser's local timezone. Use these EVERYWHERE instead of
+ * `new Date(apiValue)` so every surface agrees.
+ */
+import { formatDistanceToNow, format as dfFormat } from 'date-fns';
+
+/** Matches an explicit timezone suffix: `Z`, `+00:00`, `-0500`, etc. */
+const HAS_TZ = /(?:Z|[+-]\d{2}:?\d{2})$/;
+/** Matches a date-only value like `2026-06-29`. */
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Parse a backend timestamp into a `Date`, interpreting naive datetimes as UTC.
+ *
+ * - Already tz-qualified (`...Z` / `...+00:00`) → used as-is.
+ * - Date-only (`YYYY-MM-DD`) → local midnight (avoids the off-by-one day that
+ *   UTC-parsing date-only strings causes for negative offsets).
+ * - Naive datetime → treated as UTC (the backend convention).
+ * - `Date` / epoch number → returned/parsed directly.
+ *
+ * Returns `null` for nullish/blank/unparseable input so callers can guard.
+ */
+export function parseApiDate(
+  value: string | number | Date | null | undefined,
+): Date | null {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) return isNaN(value.getTime()) ? null : value;
+  if (typeof value === 'number') {
+    const d = new Date(value);
+    return isNaN(d.getTime()) ? null : d;
+  }
+
+  const s = value.trim();
+  if (!s) return null;
+
+  let iso: string;
+  if (HAS_TZ.test(s)) {
+    iso = s; // already unambiguous
+  } else if (DATE_ONLY.test(s)) {
+    iso = `${s}T00:00:00`; // local midnight — keep the calendar date stable
+  } else {
+    iso = `${s.replace(' ', 'T')}Z`; // naive datetime → UTC
+  }
+
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+/**
+ * Relative time (e.g. "5 minutes ago"), UTC-correct. Empty string for nullish
+ * input so it can be dropped straight into JSX.
+ */
+export function formatRelative(
+  value: string | number | Date | null | undefined,
+  options: { addSuffix?: boolean } = { addSuffix: true },
+): string {
+  const d = parseApiDate(value);
+  return d ? formatDistanceToNow(d, options) : '';
+}
+
+/**
+ * Absolute date/time formatted in the browser's local timezone via date-fns.
+ * Defaults to a friendly `MMM d, yyyy h:mm a`. Empty string for nullish input.
+ */
+export function formatDateTime(
+  value: string | number | Date | null | undefined,
+  fmt = 'MMM d, yyyy h:mm a',
+): string {
+  const d = parseApiDate(value);
+  return d ? dfFormat(d, fmt) : '';
+}
+
+/**
+ * Locale string in the browser's timezone (drop-in for `.toLocaleString()`).
+ * Empty string for nullish input.
+ */
+export function formatLocale(
+  value: string | number | Date | null | undefined,
+  options?: Intl.DateTimeFormatOptions,
+): string {
+  const d = parseApiDate(value);
+  return d ? d.toLocaleString(undefined, options) : '';
+}


### PR DESCRIPTION
## Problem
Timestamps disagreed across the app. Root cause: a recent ProtectMediaService refactor stored Event.timestamp in server-LOCAL time (datetime.now()) instead of UTC; 34 prod events affected (clean cutover vs 1299 correct). Compounded by SQLite serialising naive datetimes with no 'Z', and frontend components inconsistently treating them as UTC vs local.

## Fix
- **Storage**: `datetime.now(timezone.utc)` in `protect_media_service._retrieve_snapshot`.
- **Data**: idempotent migration `f3a2c1d4e5b6` — DST-aware Chicago→UTC for the 34 affected rows (dry-run: selects exactly 34, leaves 1299 untouched).
- **Display**: new `frontend/lib/datetime.ts` single source of truth; applied across 30 components; removed all duplicate `parseUTCTimestamp`.

## Validation
- Dry-run migration selector = 34 rows; sample conversion lands within ~0.4s of created_at.
- `tsc --noEmit`: 0 errors in touched source (65 pre-existing test-mock errors untouched).
- Considered + rejected an ORM TypeDecorator (would break `correlation_service.py:223` naive arithmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)