### PR TITLE
feat(api): self-describing UTC timestamps (...Z) for all clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,5 @@ backend/data/clips/
 /services/
 
 /graphify-out
+# graphify graph built when running graphify from backend/ (regenerable artifact)
+/backend/graphify-out

--- a/backend/app/api/v1/events.py
+++ b/backend/app/api/v1/events.py
@@ -25,6 +25,7 @@ import io
 import asyncio
 
 from app.core.database import get_db
+from app.schemas.types import iso_utc
 from app.models.event import Event
 from app.models.camera import Camera
 from app.schemas.event import (
@@ -841,13 +842,13 @@ async def export_events(
                     event_dict = {
                         "id": event.id,
                         "camera_id": event.camera_id,
-                        "timestamp": event.timestamp.isoformat(),
+                        "timestamp": iso_utc(event.timestamp),
                         "description": event.description,
                         "confidence": event.confidence,
                         "objects_detected": json.loads(event.objects_detected),
                         "thumbnail_path": event.thumbnail_path,
                         "alert_triggered": event.alert_triggered,
-                        "created_at": event.created_at.isoformat()
+                        "created_at": iso_utc(event.created_at)
                     }
                     yield json.dumps(event_dict) + "\n"
 
@@ -892,13 +893,13 @@ async def export_events(
                     writer.writerow({
                         "id": event.id,
                         "camera_id": event.camera_id,
-                        "timestamp": event.timestamp.isoformat(),
+                        "timestamp": iso_utc(event.timestamp),
                         "description": event.description,
                         "confidence": event.confidence,
                         "objects_detected": ",".join(json.loads(event.objects_detected)),
                         "thumbnail_path": event.thumbnail_path or "",
                         "alert_triggered": event.alert_triggered,
-                        "created_at": event.created_at.isoformat()
+                        "created_at": iso_utc(event.created_at)
                     })
 
                 yield buffer.getvalue()

--- a/backend/app/api/v1/homekit.py
+++ b/backend/app/api/v1/homekit.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import Session
 from pydantic import BaseModel, Field, ConfigDict
 
 from app.core.database import get_db
+from app.schemas.types import iso_utc
 from app.models.homekit import HomeKitConfig, HomeKitAccessory
 from app.models.camera import Camera
 from app.services.homekit_service import HomekitStatus
@@ -569,8 +570,8 @@ async def get_homekit_config(db: Session = Depends(get_db)):
             port=config.port,
             motion_reset_seconds=config.motion_reset_seconds,
             max_motion_duration=config.max_motion_duration,
-            created_at=config.created_at.isoformat() if config.created_at else None,
-            updated_at=config.updated_at.isoformat() if config.updated_at else None
+            created_at=iso_utc(config.created_at),
+            updated_at=iso_utc(config.updated_at)
         )
 
     except Exception as e:

--- a/backend/app/api/v1/integrations.py
+++ b/backend/app/api/v1/integrations.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 from pydantic import BaseModel, Field, field_validator
 
 from app.core.database import get_db
+from app.schemas.types import iso_utc
 from app.models.mqtt_config import MQTTConfig
 from app.services.service_container import container
 
@@ -269,8 +270,8 @@ async def get_mqtt_config(db: Session = Depends(get_db)):
         birth_message=config.birth_message,
         will_message=config.will_message,
         has_password=bool(config.password),
-        created_at=config.created_at.isoformat() if config.created_at else None,
-        updated_at=config.updated_at.isoformat() if config.updated_at else None
+        created_at=iso_utc(config.created_at),
+        updated_at=iso_utc(config.updated_at)
     )
 
 
@@ -364,8 +365,8 @@ async def update_mqtt_config(
         birth_message=config.birth_message,
         will_message=config.will_message,
         has_password=bool(config.password),
-        created_at=config.created_at.isoformat() if config.created_at else None,
-        updated_at=config.updated_at.isoformat() if config.updated_at else None
+        created_at=iso_utc(config.created_at),
+        updated_at=iso_utc(config.updated_at)
     )
 
 

--- a/backend/app/api/v1/motion_events.py
+++ b/backend/app/api/v1/motion_events.py
@@ -20,6 +20,7 @@ import csv
 import io
 
 from app.core.database import get_db
+from app.schemas.types import iso_utc
 from app.models.motion_event import MotionEvent
 from app.models.camera import Camera
 from app.schemas.motion import MotionEventResponse, MotionEventStatsResponse
@@ -151,7 +152,7 @@ async def export_motion_events(
                             pass  # Leave as empty strings
 
                     writer.writerow({
-                        "timestamp": motion_event.timestamp.isoformat() if motion_event.timestamp else "",
+                        "timestamp": iso_utc(motion_event.timestamp, default=""),
                         "camera_id": motion_event.camera_id or "",
                         "camera_name": camera_name or motion_event.camera_id or "",  # Fallback to camera_id
                         "confidence": motion_event.confidence if motion_event.confidence is not None else "",

--- a/backend/app/api/v1/push.py
+++ b/backend/app/api/v1/push.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session
 from pydantic import BaseModel, Field
 
 from app.core.database import get_db
+from app.schemas.types import iso_utc
 from app.models.push_subscription import PushSubscription
 from app.models.notification_preference import NotificationPreference
 from app.utils.vapid import get_vapid_public_key
@@ -293,7 +294,7 @@ async def subscribe(
             return SubscriptionResponse(
                 id=existing.id,
                 endpoint=endpoint_truncated,
-                created_at=existing.created_at.isoformat()
+                created_at=iso_utc(existing.created_at)
             )
 
         # Create new subscription
@@ -330,7 +331,7 @@ async def subscribe(
         return SubscriptionResponse(
             id=subscription.id,
             endpoint=endpoint_truncated,
-            created_at=subscription.created_at.isoformat()
+            created_at=iso_utc(subscription.created_at)
         )
 
     except HTTPException:
@@ -472,8 +473,8 @@ async def list_subscriptions(
                 user_id=sub.user_id,
                 endpoint=_truncate_endpoint(sub.endpoint),
                 user_agent=sub.user_agent,
-                created_at=sub.created_at.isoformat() if sub.created_at else None,
-                last_used_at=sub.last_used_at.isoformat() if sub.last_used_at else None,
+                created_at=iso_utc(sub.created_at),
+                last_used_at=iso_utc(sub.last_used_at),
             ))
 
         return SubscriptionsListResponse(
@@ -770,8 +771,8 @@ async def get_preferences(
             quiet_hours_end=preference.quiet_hours_end,
             timezone=preference.timezone,
             sound_enabled=preference.sound_enabled,
-            created_at=preference.created_at.isoformat() if preference.created_at else None,
-            updated_at=preference.updated_at.isoformat() if preference.updated_at else None,
+            created_at=iso_utc(preference.created_at),
+            updated_at=iso_utc(preference.updated_at),
         )
 
     except HTTPException:
@@ -915,8 +916,8 @@ async def update_preferences(
             quiet_hours_end=preference.quiet_hours_end,
             timezone=preference.timezone,
             sound_enabled=preference.sound_enabled,
-            created_at=preference.created_at.isoformat() if preference.created_at else None,
-            updated_at=preference.updated_at.isoformat() if preference.updated_at else None,
+            created_at=iso_utc(preference.created_at),
+            updated_at=iso_utc(preference.updated_at),
         )
 
     except HTTPException:

--- a/backend/app/api/v1/system.py
+++ b/backend/app/api/v1/system.py
@@ -133,6 +133,7 @@ from app.schemas.system import (
 from app.services.backup_service import BackupResult, RestoreResult, BackupInfo, ValidationResult
 from app.services.service_container import container
 from app.core.database import get_db
+from app.schemas.types import iso_utc
 from app.models.system_setting import SystemSetting
 from app.models.user import User, UserRole
 from app.api.v1.auth import get_current_user
@@ -2252,8 +2253,8 @@ async def get_ai_provider_stats(
                 func.max(Event.timestamp)
             ).filter(Event.provider_used.isnot(None)).first()
             time_range_data = {
-                "start": min_max[0].isoformat() if min_max[0] else None,
-                "end": min_max[1].isoformat() if min_max[1] else None
+                "start": iso_utc(min_max[0]),
+                "end": iso_utc(min_max[1])
             }
 
         return AIProviderStatsResponse(

--- a/backend/app/api/v1/voice.py
+++ b/backend/app/api/v1/voice.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.models.camera import Camera
+from app.schemas.types import iso_utc
 from app.services.voice_query_service import VoiceQueryService
 from app.services.service_container import container
 
@@ -173,8 +174,8 @@ async def voice_query(
             response=response_text,
             events_found=result.count,
             time_range=TimeRangeResponse(
-                start=parsed.time_range.start.isoformat(),
-                end=parsed.time_range.end.isoformat(),
+                start=iso_utc(parsed.time_range.start),
+                end=iso_utc(parsed.time_range.end),
                 description=parsed.time_range.description,
             ),
             cameras_involved=result.cameras_involved,

--- a/backend/app/api/v1/webhooks.py
+++ b/backend/app/api/v1/webhooks.py
@@ -19,6 +19,7 @@ from sqlalchemy import desc, and_
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
+from app.schemas.types import iso_utc
 from app.models.alert_rule import WebhookLog, AlertRule
 from app.services.webhook_service import (
     WebhookService,
@@ -290,7 +291,7 @@ async def export_webhook_logs(
     for log in logs:
         writer.writerow([
             log.id,
-            log.created_at.isoformat() if log.created_at else "",
+            iso_utc(log.created_at, default=""),
             log.alert_rule_id,
             rule_name_map.get(log.alert_rule_id, ""),
             log.event_id,

--- a/backend/app/core/json_encoding.py
+++ b/backend/app/core/json_encoding.py
@@ -1,0 +1,47 @@
+"""Global JSON encoding policy for the API.
+
+Pydantic response models get explicit-UTC datetimes via the ``UTCDateTime`` field
+type (``app.schemas.types``). But endpoints that return plain ``dict``s (or any
+value FastAPI runs through ``jsonable_encoder`` rather than a Pydantic model) would
+still serialize a datetime with ``.isoformat()`` — which emits no ``Z`` for the
+naive datetimes SQLite returns. A client then can't tell the value is UTC.
+
+``install_utc_datetime_encoder()`` overrides FastAPI's process-wide datetime
+encoder so EVERY datetime that flows through ``jsonable_encoder`` is rendered as an
+explicit-UTC ISO-8601 string (``...Z``) — the same format as ``UTCDateTime``. This
+is the safety net for non-model response paths; together they guarantee the API is
+self-describing about time zones for native clients (e.g. the iOS app).
+
+Note: this only affects datetime *objects* handed to the encoder. Code that calls
+``.isoformat()`` itself produces a string the encoder never sees — those few sites
+use ``app.schemas.types.iso_utc()`` instead.
+
+Call once at startup, before any request is served.
+"""
+
+import logging
+from datetime import datetime
+
+import fastapi.encoders as _fastapi_encoders
+
+from app.schemas.types import serialize_utc_iso
+
+logger = logging.getLogger(__name__)
+
+
+def install_utc_datetime_encoder() -> None:
+    """Patch FastAPI's global datetime encoder to emit explicit-UTC ISO-8601."""
+    _fastapi_encoders.ENCODERS_BY_TYPE[datetime] = serialize_utc_iso
+
+    # FastAPI derives a (encoder -> tuple-of-types) cache from ENCODERS_BY_TYPE at
+    # import time; jsonable_encoder consults that cache, so rebuild it after the
+    # override or the change is ignored.
+    if hasattr(_fastapi_encoders, "encoders_by_class_tuples"):
+        from collections import defaultdict
+
+        rebuilt = defaultdict(tuple)
+        for type_, encoder in _fastapi_encoders.ENCODERS_BY_TYPE.items():
+            rebuilt[encoder] += (type_,)
+        _fastapi_encoders.encoders_by_class_tuples = rebuilt
+
+    logger.info("Installed UTC datetime JSON encoder (jsonable_encoder -> ...Z)")

--- a/backend/app/schemas/alert_rule.py
+++ b/backend/app/schemas/alert_rule.py
@@ -1,6 +1,7 @@
 """Alert Rule API Pydantic schemas for request/response validation (Epic 5)"""
 from pydantic import BaseModel, Field, field_validator, model_validator
 from datetime import datetime
+from app.schemas.types import UTCDateTime
 from typing import List, Optional, Dict, Any, Literal
 import re
 
@@ -273,10 +274,10 @@ class AlertRuleResponse(BaseModel):
     conditions: AlertRuleConditions = Field(..., description="Rule conditions")
     actions: AlertRuleActions = Field(..., description="Rule actions")
     cooldown_minutes: int = Field(..., description="Cooldown period in minutes")
-    last_triggered_at: Optional[datetime] = Field(None, description="When rule last triggered")
+    last_triggered_at: Optional[UTCDateTime] = Field(None, description="When rule last triggered")
     trigger_count: int = Field(..., description="Total trigger count")
-    created_at: datetime = Field(..., description="Creation timestamp")
-    updated_at: datetime = Field(..., description="Last update timestamp")
+    created_at: UTCDateTime = Field(..., description="Creation timestamp")
+    updated_at: UTCDateTime = Field(..., description="Last update timestamp")
     # Story P12-1.1: Entity-based filtering
     entity_id: Optional[str] = Field(None, description="UUID of targeted entity")
     entity_match_mode: str = Field(default='any', description="Entity filter mode")
@@ -410,7 +411,7 @@ class WebhookLogResponse(BaseModel):
     retry_count: int = Field(..., description="Number of retry attempts")
     success: bool = Field(..., description="Whether webhook succeeded")
     error_message: Optional[str] = Field(None, description="Error details if failed")
-    created_at: datetime = Field(..., description="Execution timestamp")
+    created_at: UTCDateTime = Field(..., description="Execution timestamp")
 
     model_config = {
         "from_attributes": True,

--- a/backend/app/schemas/api_key.py
+++ b/backend/app/schemas/api_key.py
@@ -6,6 +6,7 @@ Story P13-1.3: Implement API Key List and Revoke Endpoints
 """
 from pydantic import BaseModel, Field
 from datetime import datetime
+from app.schemas.types import UTCDateTime
 from typing import Optional
 
 
@@ -20,7 +21,7 @@ class APIKeyCreateRequest(BaseModel):
         default=["read:events"],
         description="Permission scopes: read:events, read:cameras, write:cameras, admin"
     )
-    expires_at: Optional[datetime] = Field(
+    expires_at: Optional[UTCDateTime] = Field(
         None,
         description="Optional expiration date for the key"
     )
@@ -53,9 +54,9 @@ class APIKeyCreateResponse(BaseModel):
     key: str = Field(..., description="Full API key - ONLY shown once, save it now!")
     prefix: str = Field(..., description="Key prefix for identification")
     scopes: list[str]
-    expires_at: Optional[datetime]
+    expires_at: Optional[UTCDateTime]
     rate_limit_per_minute: int
-    created_at: datetime
+    created_at: UTCDateTime
 
     class Config:
         from_attributes = True
@@ -68,12 +69,12 @@ class APIKeyListResponse(BaseModel):
     prefix: str = Field(..., description="Partial key for identification (argus_xxxxxxxx...)")
     scopes: list[str]
     is_active: bool
-    expires_at: Optional[datetime]
-    last_used_at: Optional[datetime]
+    expires_at: Optional[UTCDateTime]
+    last_used_at: Optional[UTCDateTime]
     usage_count: int
     rate_limit_per_minute: int
-    created_at: datetime
-    revoked_at: Optional[datetime]
+    created_at: UTCDateTime
+    revoked_at: Optional[UTCDateTime]
 
     class Config:
         from_attributes = True
@@ -85,10 +86,10 @@ class APIKeyUsageResponse(BaseModel):
     name: str
     prefix: str
     usage_count: int
-    last_used_at: Optional[datetime]
+    last_used_at: Optional[UTCDateTime]
     last_used_ip: Optional[str]
     rate_limit_per_minute: int
-    created_at: datetime
+    created_at: UTCDateTime
 
     class Config:
         from_attributes = True

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,6 +1,7 @@
 """Authentication Pydantic schemas for request/response validation (Story P15-2)"""
 from pydantic import BaseModel, Field, EmailStr
 from datetime import datetime
+from app.schemas.types import UTCDateTime
 from typing import Optional, Literal
 
 
@@ -39,11 +40,11 @@ class UserResponse(BaseModel):
     role: str = Field(..., description="User role (admin, operator, viewer)")
     is_active: bool = Field(..., description="Account active status")
     must_change_password: bool = Field(default=False, description="Force password change on next login")
-    created_at: datetime = Field(..., description="Account creation timestamp")
-    last_login: Optional[datetime] = Field(None, description="Last login timestamp")
+    created_at: UTCDateTime = Field(..., description="Account creation timestamp")
+    last_login: Optional[UTCDateTime] = Field(None, description="Last login timestamp")
     # Story P16-1.1: Invitation tracking fields
     invited_by: Optional[str] = Field(None, description="User ID who created this account")
-    invited_at: Optional[datetime] = Field(None, description="Timestamp when user was invited")
+    invited_at: Optional[UTCDateTime] = Field(None, description="Timestamp when user was invited")
 
     class Config:
         from_attributes = True
@@ -76,11 +77,11 @@ class UserCreateResponse(BaseModel):
     email: Optional[str] = Field(None, description="Email address")
     role: str = Field(..., description="User role")
     temporary_password: Optional[str] = Field(None, description="Temporary password (if not sent via email)")
-    password_expires_at: Optional[datetime] = Field(None, description="Temporary password expiration")
-    created_at: datetime = Field(..., description="Account creation timestamp")
+    password_expires_at: Optional[UTCDateTime] = Field(None, description="Temporary password expiration")
+    created_at: UTCDateTime = Field(..., description="Account creation timestamp")
     # Story P16-1.1: Invitation tracking fields
     invited_by: Optional[str] = Field(None, description="User ID who created this account")
-    invited_at: Optional[datetime] = Field(None, description="Timestamp when user was invited")
+    invited_at: Optional[UTCDateTime] = Field(None, description="Timestamp when user was invited")
     # Story P16-1.7: Email sent indicator
     email_sent: bool = Field(default=False, description="Whether invitation email was sent")
 
@@ -98,7 +99,7 @@ class UserUpdate(BaseModel):
 class PasswordResetResponse(BaseModel):
     """Password reset response"""
     temporary_password: str = Field(..., description="New temporary password")
-    expires_at: datetime = Field(..., description="Temporary password expiration")
+    expires_at: UTCDateTime = Field(..., description="Temporary password expiration")
 
 
 # Session Management Schemas (Story P15-2.7)
@@ -107,8 +108,8 @@ class SessionResponse(BaseModel):
     id: str = Field(..., description="Session UUID")
     device_info: Optional[str] = Field(None, description="Device description")
     ip_address: Optional[str] = Field(None, description="Client IP address")
-    created_at: datetime = Field(..., description="Session creation timestamp")
-    last_active_at: datetime = Field(..., description="Last activity timestamp")
+    created_at: UTCDateTime = Field(..., description="Session creation timestamp")
+    last_active_at: UTCDateTime = Field(..., description="Last activity timestamp")
     is_current: bool = Field(default=False, description="Is this the current session")
 
     class Config:

--- a/backend/app/schemas/camera.py
+++ b/backend/app/schemas/camera.py
@@ -2,6 +2,7 @@
 from pydantic import BaseModel, Field, field_validator, model_validator
 from typing import Optional, Literal, Any, List
 from datetime import datetime
+from app.schemas.types import UTCDateTime
 import json
 
 
@@ -173,8 +174,8 @@ class CameraResponse(CameraBase):
     device_index: Optional[int] = None
     detection_zones: Optional[Any] = Field(None, description="JSON array of DetectionZone objects")
     detection_schedule: Optional[Any] = Field(None, description="JSON object: DetectionSchedule schema")
-    created_at: datetime
-    updated_at: datetime
+    created_at: UTCDateTime
+    updated_at: UTCDateTime
 
     # Phase 2: Source type and Protect integration fields
     source_type: Optional[Literal['rtsp', 'usb', 'protect']] = Field(None, description="Camera source: rtsp, usb, or protect")
@@ -423,7 +424,7 @@ class StreamSnapshotResponse(BaseModel):
     """Schema for stream snapshot response (GET /cameras/{id}/stream/snapshot)"""
 
     success: bool = Field(..., description="Whether snapshot capture succeeded")
-    timestamp: datetime = Field(..., description="Timestamp of snapshot capture")
+    timestamp: UTCDateTime = Field(..., description="Timestamp of snapshot capture")
     quality: str = Field(..., description="Quality level used for snapshot")
     image_base64: Optional[str] = Field(None, description="Base64-encoded JPEG image data")
     error: Optional[str] = Field(None, description="Error message if capture failed")
@@ -496,7 +497,7 @@ class StreamWebSocketResponse(BaseModel):
     type: Literal["quality_changed", "pong", "error", "info"] = Field(..., description="Response type")
     quality: Optional[str] = Field(None, description="Current quality level")
     message: Optional[str] = Field(None, description="Info or error message")
-    timestamp: datetime = Field(default_factory=datetime.utcnow, description="Response timestamp")
+    timestamp: UTCDateTime = Field(default_factory=datetime.utcnow, description="Response timestamp")
 
     model_config = {
         "json_schema_extra": {

--- a/backend/app/schemas/device.py
+++ b/backend/app/schemas/device.py
@@ -1,6 +1,7 @@
 """Device Pydantic schemas for request/response validation (Story P11-2.4, P11-2.5, P12-2.1)"""
 from pydantic import BaseModel, Field, field_validator
 from datetime import datetime, timezone
+from app.schemas.types import UTCDateTime
 from typing import Optional, List
 from enum import Enum
 import re
@@ -128,13 +129,13 @@ class DeviceResponse(BaseModel):
     device_id: str = Field(..., description="Device identifier")
     platform: str = Field(..., description="Device platform")
     name: Optional[str] = Field(None, description="Device name")
-    last_seen_at: Optional[datetime] = Field(None, description="Last activity timestamp")
-    created_at: datetime = Field(..., description="Registration timestamp")
+    last_seen_at: Optional[UTCDateTime] = Field(None, description="Last activity timestamp")
+    created_at: UTCDateTime = Field(..., description="Registration timestamp")
     # Story P12-2.1: Mobile device registration fields
     device_model: Optional[str] = Field(None, description="Device hardware model")
     pairing_confirmed: bool = Field(False, description="Whether pairing flow is complete")
     inactive_warning: bool = Field(False, description="True if device inactive 90+ days")
-    updated_at: Optional[datetime] = Field(None, description="Last update timestamp")
+    updated_at: Optional[UTCDateTime] = Field(None, description="Last update timestamp")
     # Quiet hours fields (Story P11-2.5)
     quiet_hours_enabled: bool = Field(False, description="Quiet hours enabled")
     quiet_hours_start: Optional[str] = Field(None, description="Quiet hours start (HH:MM)")
@@ -210,7 +211,7 @@ class DeviceRegistrationResponse(BaseModel):
     id: str = Field(..., description="Device UUID")
     device_id: str = Field(..., description="Device identifier")
     platform: str = Field(..., description="Device platform")
-    created_at: datetime = Field(..., description="Registration timestamp")
+    created_at: UTCDateTime = Field(..., description="Registration timestamp")
     is_new: bool = Field(..., description="True if new device, False if updated existing")
 
     class Config:

--- a/backend/app/schemas/discovery.py
+++ b/backend/app/schemas/discovery.py
@@ -8,6 +8,7 @@ P5-2.2: Device details (StreamProfile, DeviceInfo, DiscoveredCameraDetails)
 """
 from typing import List, Optional
 from datetime import datetime
+from app.schemas.types import UTCDateTime
 from pydantic import BaseModel, Field, ConfigDict
 
 
@@ -256,7 +257,7 @@ class DiscoveredCameraDetails(BaseModel):
         False,
         description="Whether the device requires authentication for ONVIF queries"
     )
-    discovered_at: datetime = Field(
+    discovered_at: UTCDateTime = Field(
         default_factory=datetime.utcnow,
         description="Timestamp when device details were retrieved"
     )

--- a/backend/app/schemas/event.py
+++ b/backend/app/schemas/event.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import List, Optional, Literal
 from app.schemas.feedback import FeedbackResponse
 from app.schemas.ai import BoundingBox
+from app.schemas.types import UTCDateTime
 
 # Story P7-2.1: Human-readable display names for carriers
 CARRIER_DISPLAY_NAMES = {
@@ -20,7 +21,7 @@ class MatchedEntitySummary(BaseModel):
     id: str = Field(..., description="Entity UUID")
     entity_type: str = Field(..., description="Entity type: person, vehicle, or unknown")
     name: Optional[str] = Field(None, description="User-assigned name for the entity")
-    first_seen_at: datetime = Field(..., description="Timestamp of first occurrence")
+    first_seen_at: UTCDateTime = Field(..., description="Timestamp of first occurrence")
     occurrence_count: int = Field(..., ge=1, description="Number of times this entity has been seen")
     similarity_score: Optional[float] = Field(None, ge=0.0, le=1.0, description="Match similarity score")
 
@@ -144,7 +145,7 @@ class ProcessingMetadata(BaseModel):
 class EventCreate(BaseModel):
     """Schema for creating a new event via POST /api/v1/events"""
     camera_id: str = Field(..., description="UUID of the camera that triggered the event")
-    timestamp: datetime = Field(..., description="When the event occurred (UTC with timezone)")
+    timestamp: UTCDateTime = Field(..., description="When the event occurred (UTC with timezone)")
     description: str = Field(..., min_length=1, max_length=5000, description="AI-generated natural language description")
     confidence: int = Field(..., ge=0, le=100, description="AI confidence score (0-100)")
     objects_detected: List[Literal["person", "vehicle", "animal", "package", "unknown"]] = Field(
@@ -205,7 +206,7 @@ class CorrelatedEventResponse(BaseModel):
     id: str = Field(..., description="Event UUID")
     camera_name: str = Field(..., description="Camera name for display")
     thumbnail_url: Optional[str] = Field(None, description="Full URL to thumbnail image")
-    timestamp: datetime = Field(..., description="Event timestamp (UTC)")
+    timestamp: UTCDateTime = Field(..., description="Event timestamp (UTC)")
 
     model_config = {
         "from_attributes": True,
@@ -217,7 +218,7 @@ class EventResponse(BaseModel):
     id: str = Field(..., description="Event UUID")
     camera_id: str = Field(..., description="Camera UUID")
     camera_name: Optional[str] = Field(None, description="Human-readable camera name for display")
-    timestamp: datetime = Field(..., description="Event timestamp (UTC with timezone)")
+    timestamp: UTCDateTime = Field(..., description="Event timestamp (UTC with timezone)")
     description: str = Field(..., description="AI-generated description")
     confidence: int = Field(..., ge=0, le=100, description="AI confidence score (0-100)")
     objects_detected: List[str] = Field(..., description="Detected object types")
@@ -229,7 +230,7 @@ class EventResponse(BaseModel):
     protect_event_id: Optional[str] = Field(None, description="UniFi Protect's native event ID")
     smart_detection_type: Optional[str] = Field(None, description="Protect smart detection type (person/vehicle/package/animal/motion/ring)")
     is_doorbell_ring: bool = Field(default=False, description="Whether event was triggered by doorbell ring")
-    created_at: datetime = Field(..., description="Record creation timestamp (UTC)")
+    created_at: UTCDateTime = Field(..., description="Record creation timestamp (UTC)")
     # Story P2-4.4: Multi-camera event correlation
     correlation_group_id: Optional[str] = Field(None, description="UUID linking correlated events across cameras")
     correlated_events: Optional[List["CorrelatedEventResponse"]] = Field(None, description="Related events from same correlation group")
@@ -248,7 +249,7 @@ class EventResponse(BaseModel):
     # Story P3-6.2: Vagueness detection
     vague_reason: Optional[str] = Field(None, description="Human-readable explanation of why description was flagged as vague")
     # Story P3-6.4: Re-analysis tracking
-    reanalyzed_at: Optional[datetime] = Field(None, description="Timestamp of last re-analysis (null = never re-analyzed)")
+    reanalyzed_at: Optional[UTCDateTime] = Field(None, description="Timestamp of last re-analysis (null = never re-analyzed)")
     reanalysis_count: int = Field(default=0, ge=0, description="Number of re-analyses performed")
     # Story P3-7.1: AI cost tracking
     ai_cost: Optional[float] = Field(None, description="Estimated cost in USD for AI analysis")
@@ -529,7 +530,7 @@ class EventStatsResponse(BaseModel):
     events_by_object_type: dict[str, int] = Field(..., description="Event count grouped by detected object type")
     average_confidence: float = Field(..., ge=0, le=100, description="Average confidence score")
     alerts_triggered: int = Field(..., ge=0, description="Number of events that triggered alerts")
-    time_range: dict[str, Optional[datetime]] = Field(
+    time_range: dict[str, Optional[UTCDateTime]] = Field(
         ...,
         description="Time range of queried events (start, end)"
     )
@@ -564,8 +565,8 @@ class EventStatsResponse(BaseModel):
 class EventFilterParams(BaseModel):
     """Query parameters for filtering events"""
     camera_id: Optional[str] = Field(None, description="Filter by camera UUID")
-    start_time: Optional[datetime] = Field(None, description="Filter events after this timestamp")
-    end_time: Optional[datetime] = Field(None, description="Filter events before this timestamp")
+    start_time: Optional[UTCDateTime] = Field(None, description="Filter events after this timestamp")
+    end_time: Optional[UTCDateTime] = Field(None, description="Filter events before this timestamp")
     min_confidence: Optional[int] = Field(None, ge=0, le=100, description="Minimum confidence score")
     object_types: Optional[List[str]] = Field(None, description="Filter by detected object types")
     alert_triggered: Optional[bool] = Field(None, description="Filter by alert status")
@@ -805,7 +806,7 @@ class QuerySuggestionsResponse(BaseModel):
 class PackageEventSummary(BaseModel):
     """Summary of a package delivery event for dashboard widget"""
     id: str = Field(..., description="Event UUID")
-    timestamp: datetime = Field(..., description="Event timestamp (UTC)")
+    timestamp: UTCDateTime = Field(..., description="Event timestamp (UTC)")
     delivery_carrier: Optional[str] = Field(None, description="Detected carrier code (fedex/ups/usps/amazon/dhl)")
     delivery_carrier_display: str = Field(..., description="Human-readable carrier name")
     camera_name: str = Field(..., description="Camera name for display")

--- a/backend/app/schemas/event_frame.py
+++ b/backend/app/schemas/event_frame.py
@@ -4,6 +4,7 @@ Pydantic schemas for EventFrame API responses
 Story P8-2.1: Store All Analysis Frames During Event Processing
 """
 from datetime import datetime
+from app.schemas.types import UTCDateTime
 from typing import Optional
 from pydantic import BaseModel, Field
 
@@ -22,7 +23,7 @@ class EventFrameResponse(BaseModel):
     width: Optional[int] = Field(None, ge=1, description="Frame width in pixels")
     height: Optional[int] = Field(None, ge=1, description="Frame height in pixels")
     file_size_bytes: Optional[int] = Field(None, ge=0, description="Frame file size in bytes")
-    created_at: datetime = Field(..., description="Record creation timestamp")
+    created_at: UTCDateTime = Field(..., description="Record creation timestamp")
 
     # Computed URL for frontend access
     url: Optional[str] = Field(None, description="URL to access the frame image")

--- a/backend/app/schemas/feedback.py
+++ b/backend/app/schemas/feedback.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 from typing import Literal, Optional, Dict, List
 from datetime import datetime
 from datetime import date as date_type
+from app.schemas.types import UTCDateTime
 
 
 class FeedbackCreate(BaseModel):
@@ -56,8 +57,8 @@ class FeedbackResponse(BaseModel):
     rating: str
     correction: Optional[str] = None
     correction_type: Optional[str] = None  # Story P9-3.3: Correction type
-    created_at: datetime
-    updated_at: Optional[datetime] = None
+    created_at: UTCDateTime
+    updated_at: Optional[UTCDateTime] = None
     was_edited: bool = False  # Story P10-4.3: Indicates if feedback was modified
 
     model_config = {"from_attributes": True}
@@ -190,7 +191,7 @@ class SummaryFeedbackResponse(BaseModel):
     summary_id: str
     rating: str
     correction_text: Optional[str] = None
-    created_at: datetime
-    updated_at: Optional[datetime] = None
+    created_at: UTCDateTime
+    updated_at: Optional[UTCDateTime] = None
 
     model_config = {"from_attributes": True}

--- a/backend/app/schemas/homekit_connectivity.py
+++ b/backend/app/schemas/homekit_connectivity.py
@@ -5,6 +5,7 @@ Pydantic schemas for the connectivity test endpoint that checks
 mDNS visibility and port accessibility for troubleshooting HomeKit discovery issues.
 """
 from datetime import datetime
+from app.schemas.types import UTCDateTime
 from typing import List, Optional
 
 from pydantic import BaseModel, Field, ConfigDict
@@ -47,7 +48,7 @@ class HomeKitConnectivityResponse(BaseModel):
         ...,
         description="Configured bridge name"
     )
-    test_timestamp: datetime = Field(
+    test_timestamp: UTCDateTime = Field(
         default_factory=datetime.utcnow,
         description="Timestamp when the connectivity test was performed"
     )

--- a/backend/app/schemas/homekit_diagnostics.py
+++ b/backend/app/schemas/homekit_diagnostics.py
@@ -6,6 +6,7 @@ Story P7-1.2 adds connectivity test response schema.
 Story P7-3.3 adds camera streaming diagnostics schemas.
 """
 from datetime import datetime
+from app.schemas.types import UTCDateTime
 from typing import List, Optional
 from pydantic import BaseModel, Field, ConfigDict
 
@@ -22,7 +23,7 @@ class HomeKitDiagnosticEntry(BaseModel):
     - network: IP binding, port info
     - mdns: mDNS/Bonjour advertisement status
     """
-    timestamp: datetime = Field(..., description="When the event occurred")
+    timestamp: UTCDateTime = Field(..., description="When the event occurred")
     level: str = Field(
         ...,
         description="Log level: debug, info, warning, error",
@@ -74,7 +75,7 @@ class LastEventDeliveryInfo(BaseModel):
     camera_id: str = Field(..., description="Camera that triggered the event")
     camera_name: Optional[str] = Field(None, description="Human-readable camera name (Story P7-1.4)")
     sensor_type: str = Field(..., description="Type of sensor (motion, occupancy, vehicle, etc.)")
-    timestamp: datetime = Field(..., description="When the event was delivered")
+    timestamp: UTCDateTime = Field(..., description="When the event was delivered")
     delivered: bool = Field(..., description="Whether delivery was successful")
 
     model_config = ConfigDict(
@@ -199,7 +200,7 @@ class CameraStreamInfo(BaseModel):
         True,
         description="Whether snapshot capture is supported"
     )
-    last_snapshot: Optional[datetime] = Field(
+    last_snapshot: Optional[UTCDateTime] = Field(
         None,
         description="Timestamp of last snapshot capture"
     )

--- a/backend/app/schemas/homekit_test_event.py
+++ b/backend/app/schemas/homekit_test_event.py
@@ -6,6 +6,7 @@ Allows triggering motion/occupancy/vehicle/animal/package/doorbell events
 from the diagnostics UI to verify HomeKit event delivery.
 """
 from datetime import datetime
+from app.schemas.types import UTCDateTime
 from typing import Optional, Literal
 from pydantic import BaseModel, Field, ConfigDict
 
@@ -73,7 +74,7 @@ class HomeKitTestEventResponse(BaseModel):
         0,
         description="Number of connected HomeKit clients that received the event"
     )
-    timestamp: datetime = Field(
+    timestamp: UTCDateTime = Field(
         default_factory=datetime.utcnow,
         description="When the event was triggered"
     )

--- a/backend/app/schemas/mobile_auth.py
+++ b/backend/app/schemas/mobile_auth.py
@@ -4,6 +4,7 @@ Mobile Authentication Schemas (Story P12-3.1)
 Pydantic schemas for mobile device pairing and token management.
 """
 from datetime import datetime
+from app.schemas.types import UTCDateTime
 from typing import Optional, Literal
 from pydantic import BaseModel, Field
 
@@ -24,7 +25,7 @@ class PairingCodeResponse(BaseModel):
     """Response containing the generated pairing code."""
     code: str = Field(..., description="6-digit pairing code to display")
     expires_in: int = Field(..., description="Seconds until code expires")
-    expires_at: datetime = Field(..., description="Absolute expiration time")
+    expires_at: UTCDateTime = Field(..., description="Absolute expiration time")
 
 
 class PairingConfirmRequest(BaseModel):
@@ -97,8 +98,8 @@ class DeviceTokenInfo(BaseModel):
     device_name: Optional[str] = Field(None, description="Device name")
     platform: str = Field(..., description="Device platform")
     has_valid_token: bool = Field(..., description="Whether device has valid refresh token")
-    token_expires_at: Optional[datetime] = Field(None, description="Token expiration time")
-    last_used_at: Optional[datetime] = Field(None, description="Last token use time")
+    token_expires_at: Optional[UTCDateTime] = Field(None, description="Token expiration time")
+    last_used_at: Optional[UTCDateTime] = Field(None, description="Last token use time")
 
 
 class PendingPairingInfo(BaseModel):
@@ -107,8 +108,8 @@ class PendingPairingInfo(BaseModel):
     device_name: Optional[str] = Field(None, description="Requesting device name")
     device_model: Optional[str] = Field(None, description="Requesting device model")
     platform: str = Field(..., description="Requesting device platform")
-    expires_at: datetime = Field(..., description="Code expiration time")
-    created_at: datetime = Field(..., description="Request creation time")
+    expires_at: UTCDateTime = Field(..., description="Code expiration time")
+    created_at: UTCDateTime = Field(..., description="Request creation time")
 
 
 class PendingPairingsResponse(BaseModel):

--- a/backend/app/schemas/motion.py
+++ b/backend/app/schemas/motion.py
@@ -2,6 +2,7 @@
 from pydantic import BaseModel, Field, field_validator
 from typing import Optional, Literal, List, Dict
 from datetime import datetime
+from app.schemas.types import UTCDateTime
 
 
 class BoundingBox(BaseModel):
@@ -109,14 +110,14 @@ class MotionEventResponse(BaseModel):
     """Schema for motion event API response"""
     id: str = Field(..., description="Event UUID")
     camera_id: str = Field(..., description="Camera UUID")
-    timestamp: datetime = Field(..., description="Motion detection timestamp")
+    timestamp: UTCDateTime = Field(..., description="Motion detection timestamp")
     confidence: float = Field(..., ge=0.0, le=1.0, description="Confidence score")
     motion_intensity: Optional[float] = Field(None, description="Motion intensity metric")
     algorithm_used: str = Field(..., description="Algorithm that detected motion")
     bounding_box: Optional[Dict] = Field(None, description="Motion bounding box (JSON)")
     frame_thumbnail: Optional[str] = Field(None, description="Base64-encoded JPEG thumbnail")
     ai_event_id: Optional[str] = Field(None, description="Linked AI event ID (F3)")
-    created_at: datetime = Field(..., description="Record creation timestamp")
+    created_at: UTCDateTime = Field(..., description="Record creation timestamp")
 
     model_config = {
         "from_attributes": True,

--- a/backend/app/schemas/mqtt.py
+++ b/backend/app/schemas/mqtt.py
@@ -10,6 +10,7 @@ Defines Pydantic schemas for MQTT payloads:
 All schemas serialize to JSON for MQTT publishing.
 """
 from datetime import datetime
+from app.schemas.types import UTCDateTime
 from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
@@ -32,7 +33,7 @@ class CameraStatusPayload(BaseModel):
     camera_name: str
     status: Literal["online", "offline", "unavailable"]
     source_type: str = Field(description="Camera type: rtsp, usb, or protect")
-    last_updated: datetime
+    last_updated: UTCDateTime
 
 
 class CameraCountsPayload(BaseModel):
@@ -52,7 +53,7 @@ class CameraCountsPayload(BaseModel):
     camera_name: str
     events_today: int = Field(ge=0, description="Events since midnight")
     events_this_week: int = Field(ge=0, description="Events since Monday")
-    last_updated: datetime
+    last_updated: UTCDateTime
 
 
 class CameraActivityPayload(BaseModel):
@@ -70,7 +71,7 @@ class CameraActivityPayload(BaseModel):
     """
     camera_id: str
     state: Literal["ON", "OFF"]
-    last_event_at: Optional[datetime] = None
+    last_event_at: Optional[UTCDateTime] = None
 
 
 class LastEventPayload(BaseModel):
@@ -90,6 +91,6 @@ class LastEventPayload(BaseModel):
     camera_id: str
     camera_name: str
     event_id: str
-    timestamp: datetime
+    timestamp: UTCDateTime
     description_snippet: str = Field(max_length=100, description="First 100 chars of description")
     smart_detection_type: Optional[str] = None

--- a/backend/app/schemas/prompt_insight.py
+++ b/backend/app/schemas/prompt_insight.py
@@ -10,6 +10,7 @@ Defines request/response models for:
 from pydantic import BaseModel, Field
 from typing import List, Optional, Dict
 from datetime import datetime
+from app.schemas.types import UTCDateTime
 from enum import Enum
 
 
@@ -182,7 +183,7 @@ class PromptHistoryEntry(BaseModel):
         None,
         description="Camera ID if this is a camera-specific prompt"
     )
-    created_at: datetime = Field(..., description="When this version was created")
+    created_at: UTCDateTime = Field(..., description="When this version was created")
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/schemas/protect.py
+++ b/backend/app/schemas/protect.py
@@ -2,6 +2,7 @@
 from pydantic import BaseModel, Field, field_validator
 from typing import Optional, List, Literal
 from datetime import datetime, timezone
+from app.schemas.types import UTCDateTime
 import uuid
 
 
@@ -53,10 +54,10 @@ class ProtectControllerResponse(ProtectControllerBase):
     id: str = Field(..., description="Controller UUID")
     username: str = Field(..., description="Protect authentication username")
     is_connected: bool = Field(..., description="Current connection status")
-    last_connected_at: Optional[datetime] = Field(None, description="Last successful connection timestamp")
+    last_connected_at: Optional[UTCDateTime] = Field(None, description="Last successful connection timestamp")
     last_error: Optional[str] = Field(None, description="Last connection error message")
-    created_at: datetime
-    updated_at: datetime
+    created_at: UTCDateTime
+    updated_at: UTCDateTime
 
     # Note: password field is intentionally omitted (write-only field)
 
@@ -86,7 +87,7 @@ class MetaResponse(BaseModel):
     """Standard meta response object"""
 
     request_id: str = Field(default_factory=lambda: str(uuid.uuid4()), description="Unique request identifier")
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Response timestamp")
+    timestamp: UTCDateTime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Response timestamp")
     count: Optional[int] = Field(None, description="Number of items (for list responses)")
 
 
@@ -265,11 +266,11 @@ class ProtectCameraDiscoveryMeta(BaseModel):
     """Meta response for camera discovery (AC6)"""
 
     request_id: str = Field(default_factory=lambda: str(uuid.uuid4()), description="Unique request identifier")
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Response timestamp")
+    timestamp: UTCDateTime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Response timestamp")
     count: int = Field(..., description="Number of cameras discovered")
     controller_id: str = Field(..., description="Controller ID that was queried")
     cached: bool = Field(..., description="Whether results were returned from cache")
-    cached_at: Optional[datetime] = Field(None, description="When results were cached (if cached)")
+    cached_at: Optional[UTCDateTime] = Field(None, description="When results were cached (if cached)")
     warning: Optional[str] = Field(None, description="Warning message if any issues occurred")
 
 
@@ -435,8 +436,8 @@ class TestClipDownloadRequest(BaseModel):
     """Request body for testing clip download (Story P3-1.5)"""
 
     camera_id: str = Field(..., description="Internal camera UUID (from cameras table)")
-    start_time: datetime = Field(..., description="Clip start time (ISO 8601 with timezone)")
-    end_time: datetime = Field(..., description="Clip end time (ISO 8601 with timezone)")
+    start_time: UTCDateTime = Field(..., description="Clip start time (ISO 8601 with timezone)")
+    end_time: UTCDateTime = Field(..., description="Clip end time (ISO 8601 with timezone)")
 
     @field_validator('end_time')
     @classmethod

--- a/backend/app/schemas/system.py
+++ b/backend/app/schemas/system.py
@@ -5,6 +5,7 @@ Pydantic schemas for system-level configuration and monitoring endpoints.
 """
 from pydantic import BaseModel, Field, field_validator
 from datetime import datetime
+from app.schemas.types import UTCDateTime
 from typing import Optional, Literal
 
 
@@ -573,7 +574,7 @@ class CircuitBreakerStatusResponse(BaseModel):
     failure_count: int
     current_failure_rate: Optional[float] = None
     recent_window_size: int
-    last_failure_time: Optional[datetime] = None
+    last_failure_time: Optional[UTCDateTime] = None
 
 
 class AIResilienceResponse(BaseModel):
@@ -587,4 +588,4 @@ class AIResilienceResponse(BaseModel):
     grok: Optional[CircuitBreakerStatusResponse] = None
     claude: Optional[CircuitBreakerStatusResponse] = None
     gemini: Optional[CircuitBreakerStatusResponse] = None
-    last_reset: Optional[datetime] = None  # Global last reset timestamp (for all admins)
+    last_reset: Optional[UTCDateTime] = None  # Global last reset timestamp (for all admins)

--- a/backend/app/schemas/types.py
+++ b/backend/app/schemas/types.py
@@ -1,0 +1,63 @@
+"""Shared Pydantic field types for API schemas.
+
+`UTCDateTime` makes the API self-describing about time zones. The backend stores
+all timestamps in UTC, but SQLite returns *naive* datetimes, so Pydantic's default
+serialization emits e.g. ``2026-06-29T09:08:20`` with no offset — a client cannot
+tell that is UTC and may render it as local time (the bug fixed in PR #502).
+
+`UTCDateTime` serializes every datetime as an explicit-UTC ISO-8601 string with a
+``Z`` suffix (``2026-06-29T09:08:20.850453Z``):
+
+  * naive datetime  -> assumed UTC (the project convention), tagged ``Z``
+  * aware datetime  -> converted to UTC, tagged ``Z``
+
+This is what native clients (e.g. the planned iOS app, whose
+``ISO8601DateFormatter`` expects an offset) and JS ``new Date()`` both parse
+unambiguously. Validation/parsing of inbound values is unchanged — only JSON
+serialization is affected (``when_used='json'``) — so request bodies keep working
+exactly as before.
+
+OpenAPI still advertises ``{type: string, format: date-time}`` so generated client
+models keep their date types.
+
+Usage in a schema::
+
+    from app.schemas.types import UTCDateTime
+
+    class EventResponse(BaseModel):
+        created_at: UTCDateTime
+        ended_at: Optional[UTCDateTime] = None
+"""
+
+from datetime import datetime, timezone
+from typing import Annotated, Optional
+
+from pydantic import PlainSerializer, WithJsonSchema
+
+
+def serialize_utc_iso(value: datetime) -> str:
+    """Render a datetime as an explicit-UTC ISO-8601 string with a ``Z`` suffix."""
+    if value.tzinfo is None:
+        # Project convention: naive datetimes are UTC.
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def iso_utc(value: Optional[datetime], *, default=None):
+    """Manual-serialization helper for non-Pydantic paths (raw dict responses).
+
+    Use instead of ``value.isoformat()`` so hand-built response dicts emit the same
+    explicit-UTC ``...Z`` string as ``UTCDateTime`` fields. ``default`` is returned
+    for ``None`` so each call site can preserve its existing empty-value contract
+    (``iso_utc(x)`` -> ``None``; ``iso_utc(x, default="")`` -> ``""``).
+    """
+    return serialize_utc_iso(value) if value is not None else default
+
+
+# Drop-in replacement for `datetime` in response (and request) schemas. Keeps the
+# standard datetime validator; only changes JSON serialization + OpenAPI schema.
+UTCDateTime = Annotated[
+    datetime,
+    PlainSerializer(serialize_utc_iso, return_type=str, when_used="json"),
+    WithJsonSchema({"type": "string", "format": "date-time"}, mode="serialization"),
+]

--- a/backend/main.py
+++ b/backend/main.py
@@ -27,6 +27,7 @@ from app.core.config import settings
 from app.core.database import engine, Base
 from app.core.logging_config import setup_logging, get_logger
 from app.core.metrics import init_metrics, get_metrics, get_content_type, update_system_metrics
+from app.core.json_encoding import install_utc_datetime_encoder
 from app.middleware.logging_middleware import RequestLoggingMiddleware
 from app.middleware.auth_middleware import AuthMiddleware
 from app.middleware.last_seen import LastSeenMiddleware
@@ -874,6 +875,12 @@ OPENAPI_TAGS = [
     {"name": "System Notifications", "description": "System alerts and cost notifications"},
     {"name": "API Keys", "description": "API key management for external integrations"},
 ]
+
+# Make every datetime the API emits self-describing as UTC (...Z), so native
+# clients (web + the planned iOS app) never have to guess the time zone. Pydantic
+# response models use the UTCDateTime field type; this covers the dict/jsonable
+# paths. Installed before any request is served.
+install_utc_datetime_encoder()
 
 # Create FastAPI app with enhanced OpenAPI configuration
 app = FastAPI(


### PR DESCRIPTION
## Why
Follow-up to #502. The web app was fixed by having the frontend treat naive API datetimes as UTC, but the **API itself is still ambiguous** — SQLite serializes naive datetimes with no offset (`2026-06-29T09:08:20`). With a **native iOS client planned**, the API should be self-describing so any client parses timestamps unambiguously.

## What
Three layers covering FastAPI's three serialization paths, all sharing one formatter (`serialize_utc_iso` → `...Z`):
1. **`UTCDateTime` field type** on all **73** datetime fields across 18 schemas → every `response_model` endpoint emits `Z`. Preserves OpenAPI `format: date-time` for iOS codegen. Serialization-only (`when_used='json'`) — inbound validation unchanged.
2. **Global `jsonable_encoder` override** (`app/core/json_encoding.py`, wired in `main.py`) → dict endpoints returning datetime objects emit `Z`.
3. **`iso_utc()` helper** for ~16 manual `.isoformat()` sites that bypass both (events JSON/CSV export, push/integrations/homekit/motion_events/webhooks/system/voice), preserving each site's None/"" contract.

## Validation
- naive→`Z`, aware→converted-to-UTC `Z`, inbound parsing intact.
- 217 schema/serialization tests pass (pre-existing unrelated failures confirmed via `git stash`).
- Layer 2/3 mechanics verified on prod's Python 3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)