### PR TITLE
chore(time): replace deprecated datetime.utcnow() with aware UTC

### DIFF
--- a/backend/app/api/v1/cameras.py
+++ b/backend/app/api/v1/cameras.py
@@ -2493,7 +2493,7 @@ async def get_stream_snapshot(
         404: Camera not found
         503: Camera not available for streaming
     """
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     camera_id_str = str(camera_id)
 
@@ -2517,7 +2517,7 @@ async def get_stream_snapshot(
     if not rtsp_url:
         return StreamSnapshotResponse(
             success=False,
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             quality=quality,
             error="Camera does not have a stream URL configured"
         )
@@ -2529,14 +2529,14 @@ async def get_stream_snapshot(
         image_base64 = f"data:image/jpeg;base64,{base64.b64encode(image_bytes).decode('utf-8')}"
         return StreamSnapshotResponse(
             success=True,
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             quality=quality,
             image_base64=image_base64
         )
     else:
         return StreamSnapshotResponse(
             success=False,
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             quality=quality,
             error="Failed to capture snapshot from camera"
         )

--- a/backend/app/schemas/ai.py
+++ b/backend/app/schemas/ai.py
@@ -1,5 +1,4 @@
 """Pydantic schemas for AI service endpoints"""
-from datetime import datetime
 from typing import Optional, List, Dict, Any, Literal
 from pydantic import BaseModel, Field
 

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -25,7 +25,7 @@ rather than going through AIService.
 
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, List, Dict, Any
 
 import numpy as np
@@ -485,7 +485,7 @@ class AIService:
         start_time = time.time()
 
         if timestamp is None:
-            timestamp = datetime.utcnow().isoformat()
+            timestamp = datetime.now(timezone.utc).isoformat()
         if detected_objects is None:
             detected_objects = []
 

--- a/backend/app/services/homekit_camera.py
+++ b/backend/app/services/homekit_camera.py
@@ -36,7 +36,7 @@ from enum import Enum
 from typing import Dict, List, Optional, Any, Tuple
 from dataclasses import dataclass, field
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from app.core.metrics import (
     record_homekit_stream_start,
@@ -722,7 +722,7 @@ class HomeKitCameraAccessory:
         """
         if self._snapshot_cache is None or self._snapshot_timestamp is None:
             return False
-        age = (datetime.utcnow() - self._snapshot_timestamp).total_seconds()
+        age = (datetime.now(timezone.utc) - self._snapshot_timestamp).total_seconds()
         return age < SNAPSHOT_CACHE_SECONDS
 
     @property
@@ -761,7 +761,7 @@ class HomeKitCameraAccessory:
                 f"Snapshot cache hit for camera {self.camera_name}",
                 extra={
                     "camera_id": self.camera_id,
-                    "cache_age_seconds": (datetime.utcnow() - self._snapshot_timestamp).total_seconds()
+                    "cache_age_seconds": (datetime.now(timezone.utc) - self._snapshot_timestamp).total_seconds()
                     if self._snapshot_timestamp else 0
                 }
             )
@@ -797,7 +797,7 @@ class HomeKitCameraAccessory:
             if result.returncode == 0 and result.stdout:
                 # Story P7-3.2 AC3: Store in cache with timestamp
                 self._snapshot_cache = result.stdout
-                self._snapshot_timestamp = datetime.utcnow()
+                self._snapshot_timestamp = datetime.now(timezone.utc)
 
                 logger.debug(
                     f"Captured and cached snapshot for camera {self.camera_name}",

--- a/backend/app/services/onvif_discovery_service.py
+++ b/backend/app/services/onvif_discovery_service.py
@@ -21,7 +21,7 @@ import logging
 from app.core.decorators import singleton
 import re
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional, Set, Tuple
 from dataclasses import dataclass, field
 from urllib.parse import urlparse, urlunparse, quote
@@ -635,7 +635,7 @@ class ONVIFDiscoveryService:
                 profiles=profiles,
                 primary_rtsp_url=primary_rtsp_url,
                 requires_auth=len(profiles) == 0,  # Assume auth needed if no profiles
-                discovered_at=datetime.utcnow()
+                discovered_at=datetime.now(timezone.utc)
             )
 
             return DeviceDetailsResult(

--- a/backend/app/services/query_adaptive/query_cache.py
+++ b/backend/app/services/query_adaptive/query_cache.py
@@ -22,7 +22,7 @@ import logging
 import threading
 import time
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -51,18 +51,18 @@ class CachedQueryResult:
     relevance_scores: List[float]
     quality_scores: List[float] = field(default_factory=list)
     combined_scores: List[float] = field(default_factory=list)
-    cached_at: datetime = field(default_factory=lambda: datetime.utcnow())
+    cached_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     ttl_seconds: int = 300  # 5 minutes (AC5)
 
     @property
     def is_expired(self) -> bool:
         """Check if this cache entry has expired."""
-        return datetime.utcnow() > self.cached_at + timedelta(seconds=self.ttl_seconds)
+        return datetime.now(timezone.utc) > self.cached_at + timedelta(seconds=self.ttl_seconds)
 
     @property
     def age_seconds(self) -> float:
         """Get the age of this cache entry in seconds."""
-        return (datetime.utcnow() - self.cached_at).total_seconds()
+        return (datetime.now(timezone.utc) - self.cached_at).total_seconds()
 
 
 class QueryCache:
@@ -179,7 +179,7 @@ class QueryCache:
                 relevance_scores=relevance_scores,
                 quality_scores=quality_scores or [],
                 combined_scores=combined_scores or [],
-                cached_at=datetime.utcnow(),
+                cached_at=datetime.now(timezone.utc),
                 ttl_seconds=self.ttl_seconds,
             )
 

--- a/backend/app/services/video_analysis_service.py
+++ b/backend/app/services/video_analysis_service.py
@@ -14,7 +14,7 @@ Extracted from ai_service.py during Phase 3.5 of the decomposition.
 
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional, Any
 
@@ -59,7 +59,7 @@ class VideoAnalysisService:
         start_time = time.time()
 
         if timestamp is None:
-            timestamp = datetime.utcnow().isoformat()
+            timestamp = datetime.now(timezone.utc).isoformat()
         if detected_objects is None:
             detected_objects = []
 

--- a/backend/app/services/vision_analysis_orchestrator.py
+++ b/backend/app/services/vision_analysis_orchestrator.py
@@ -30,7 +30,7 @@ import base64
 import io
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, Any
 
 import numpy as np
@@ -118,7 +118,7 @@ class VisionAnalysisOrchestrator:
         start_time = time.time()
 
         if timestamp is None:
-            timestamp = datetime.utcnow().isoformat()
+            timestamp = datetime.now(timezone.utc).isoformat()
         if detected_objects is None:
             detected_objects = []
 
@@ -275,7 +275,7 @@ class VisionAnalysisOrchestrator:
         start_time = time.time()
 
         if timestamp is None:
-            timestamp = datetime.utcnow().isoformat()
+            timestamp = datetime.now(timezone.utc).isoformat()
         if detected_objects is None:
             detected_objects = []
 


### PR DESCRIPTION
Replaces all 15 `datetime.utcnow()` calls (deprecated in 3.12, returns naive) with `datetime.now(timezone.utc)` across 7 files, and removes an unused `datetime` import in `schemas/ai.py`.

**Safety-audited** (aware/naive arithmetic raises TypeError — the #502 lesson): `.isoformat()` string sites and Pydantic response fields have no arithmetic; `homekit_camera`/`query_cache` do internal arithmetic but only against other `utcnow()` values, so each file's sites were converted as a complete group. None feed `Event.timestamp`.

Validation: ast-parse OK (8 files), zero `utcnow()` remaining, arithmetic modules import cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)