### PR TITLE
fix(ws): WebSocket auth crash — get_current_user needs a Request

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -1,5 +1,5 @@
 """Authentication API endpoints (Story 6.3, P15-2)"""
-from fastapi import APIRouter, Depends, HTTPException, status, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, status, Request, Response, WebSocket
 from sqlalchemy.orm import Session
 from slowapi import Limiter
 from slowapi.util import get_remote_address
@@ -94,6 +94,47 @@ def get_current_user(request: Request, db: Session = Depends(get_db)) -> User:
             detail="User account disabled",
         )
 
+    return user
+
+
+def authenticate_websocket(
+    websocket: WebSocket, token: Optional[str] = None
+) -> Optional[User]:
+    """WebSocket-safe variant of get_current_user.
+
+    Resolves the authenticated user from (in order): an explicit ``?token=`` JWT
+    query param, the session cookie, or an ``Authorization: Bearer`` header.
+
+    A WebSocket route cannot depend on ``get_current_user``: that dependency
+    requires a ``Request`` (which FastAPI cannot inject for a WebSocket — it
+    raises ``get_current_user() missing 1 required positional argument:
+    'request'``) and it raises 401 instead of returning ``None``. This reads
+    straight from the ``WebSocket`` and returns ``None`` when unauthenticated so
+    the caller can ``websocket.close(...)`` with an appropriate code.
+    """
+    jwt_token = token or websocket.cookies.get(COOKIE_NAME)
+    if not jwt_token:
+        auth_header = websocket.headers.get("Authorization")
+        if auth_header and auth_header.startswith("Bearer "):
+            jwt_token = auth_header[7:]
+    if not jwt_token:
+        return None
+
+    try:
+        payload = decode_access_token(jwt_token)
+    except TokenError:
+        return None
+
+    user_id = payload.get("user_id")
+    if not user_id:
+        return None
+
+    from app.core.database import get_db_session
+    with get_db_session() as db:
+        user = db.query(User).filter(User.id == user_id).first()
+
+    if not user or not user.is_active:
+        return None
     return user
 
 

--- a/backend/app/api/v1/system.py
+++ b/backend/app/api/v1/system.py
@@ -136,7 +136,7 @@ from app.core.database import get_db
 from app.schemas.types import iso_utc
 from app.models.system_setting import SystemSetting
 from app.models.user import User, UserRole
-from app.api.v1.auth import get_current_user
+from app.api.v1.auth import get_current_user, authenticate_websocket
 from app.utils.encryption import encrypt_password, decrypt_password, mask_sensitive, is_encrypted
 from app.core.config import settings
 
@@ -935,7 +935,6 @@ async def ai_processing_stream(
 async def ai_processing_ws(
     websocket: WebSocket,
     token: Optional[str] = Query(None),
-    current_user: User = Depends(get_current_user),
 ):
     """Bidirectional WebSocket for real-time AI event streaming + client commands.
 
@@ -978,17 +977,11 @@ async def ai_processing_ws(
 
     Recommended client behavior: implement exponential backoff reconnect + re-apply last filters on reconnect.
     """
-    # Support query-param token for non-browser clients
-    if not current_user and token:
-        try:
-            payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
-            username = payload.get("sub")
-            if username:
-                from app.core.database import get_db_session
-                with get_db_session() as db:
-                    current_user = db.query(User).filter(User.username == username).first()
-        except JWTError:
-            pass
+    # Resolve the user from the session cookie (browser), ?token= JWT (scripts),
+    # or an Authorization: Bearer header. A WebSocket route cannot use the
+    # get_current_user dependency (it needs a Request and raises 401), so we
+    # authenticate explicitly here.
+    current_user = authenticate_websocket(websocket, token)
 
     if not current_user or current_user.role != UserRole.ADMIN:
         await websocket.close(code=1008, reason="Admin role required")
@@ -1135,7 +1128,6 @@ async def ai_processing_ws(
 async def ai_processing_hot_ws(
     websocket: WebSocket,
     token: Optional[str] = Query(None),
-    current_user: User = Depends(get_current_user),
 ):
     """Lightweight bidirectional WebSocket that **only** streams hot list updates (`hot_update` messages).
 
@@ -1254,16 +1246,11 @@ async def ai_processing_hot_ws(
     connectHotWS();
     ```
     """
-    if not current_user and token:
-        try:
-            payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
-            username = payload.get("sub")
-            if username:
-                from app.core.database import get_db_session
-                with get_db_session() as db:
-                    current_user = db.query(User).filter(User.username == username).first()
-        except JWTError:
-            pass
+    # Resolve the user from the session cookie (browser), ?token= JWT (scripts),
+    # or an Authorization: Bearer header. A WebSocket route cannot use the
+    # get_current_user dependency (it needs a Request and raises 401), so we
+    # authenticate explicitly here.
+    current_user = authenticate_websocket(websocket, token)
 
     if not current_user or current_user.role != UserRole.ADMIN:
         await websocket.close(code=1008, reason="Admin role required")


### PR DESCRIPTION
## Problem
`/api/v1/system/ai-processing-ws` and `/ai-processing-hot-ws` declared `current_user: User = Depends(get_current_user)`. `get_current_user` requires `request: Request`, which FastAPI cannot inject for a WebSocket — so **every connection threw** `TypeError: get_current_user() missing 1 required positional argument: 'request'` before the handler ran. Found via prod journal (31×/2000 lines); it was the top source filling `/var/log` (#505).

## Fix
- New `authenticate_websocket(websocket, token)` in `auth.py`: WS-safe, resolves the user from `?token=`, session cookie, or Bearer header via `decode_access_token`, returns `None` instead of raising.
- Both WS endpoints drop the bad `Depends` and call it explicitly, keeping the admin-role check + `1008` close.
- Bonus: the old in-body fallback only honored `?token=` (username/`sub`) and ignored the **cookie** — browser dashboard clients now authenticate correctly.

## Validation
- `py_compile` clean; wiring verified.
- Post-deploy: confirm unauthenticated WS connect closes `1008` (not crash) and the journal `TypeError` stops. Related to #505.

🤖 Generated with [Claude Code](https://claude.com/claude-code)