### PR TITLE
chore(schemas): migrate class Config → ConfigDict (Pydantic 2.13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
           # Use secret if available, otherwise use a valid test key
           # Note: This test key is intentionally hardcoded for CI - it's only used for testing
           ENCRYPTION_KEY: ${{ secrets.TEST_ENCRYPTION_KEY || 'YhLHon9m3QOhb394b-Qa761Vgj9ij3oLlT-moS2oRcg=' }}
+          # JWT_SECRET_KEY is required (no default) — Settings() in conftest fails
+          # without it, breaking collection. Mirrors the startup-smoke job.
+          JWT_SECRET_KEY: ci-smoke-test-secret-not-for-production
           PYTHONPATH: .
 
       - name: Upload backend coverage to Codecov

--- a/backend/app/schemas/api_key.py
+++ b/backend/app/schemas/api_key.py
@@ -4,7 +4,7 @@ Pydantic schemas for API Key management.
 Story P13-1.2: Implement API Key Generation Endpoint
 Story P13-1.3: Implement API Key List and Revoke Endpoints
 """
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 from datetime import datetime
 from app.schemas.types import UTCDateTime
 from typing import Optional
@@ -32,8 +32,8 @@ class APIKeyCreateRequest(BaseModel):
         description="Maximum requests per minute (1-10000)"
     )
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "name": "Home Assistant Integration",
                 "scopes": ["read:events", "read:cameras"],
@@ -41,6 +41,7 @@ class APIKeyCreateRequest(BaseModel):
                 "rate_limit_per_minute": 100
             }
         }
+    )
 
 
 class APIKeyCreateResponse(BaseModel):
@@ -58,8 +59,7 @@ class APIKeyCreateResponse(BaseModel):
     rate_limit_per_minute: int
     created_at: UTCDateTime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class APIKeyListResponse(BaseModel):
@@ -76,8 +76,7 @@ class APIKeyListResponse(BaseModel):
     created_at: UTCDateTime
     revoked_at: Optional[UTCDateTime]
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class APIKeyUsageResponse(BaseModel):
@@ -91,8 +90,7 @@ class APIKeyUsageResponse(BaseModel):
     rate_limit_per_minute: int
     created_at: UTCDateTime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class MessageResponse(BaseModel):

--- a/backend/app/schemas/device.py
+++ b/backend/app/schemas/device.py
@@ -1,5 +1,5 @@
 """Device Pydantic schemas for request/response validation (Story P11-2.4, P11-2.5, P12-2.1)"""
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, ConfigDict
 from datetime import datetime, timezone
 from app.schemas.types import UTCDateTime
 from typing import Optional, List
@@ -143,8 +143,7 @@ class DeviceResponse(BaseModel):
     quiet_hours_timezone: str = Field("UTC", description="Timezone for quiet hours")
     quiet_hours_override_critical: bool = Field(True, description="Allow critical alerts during quiet hours")
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class DevicePreferencesUpdate(BaseModel):
@@ -214,5 +213,4 @@ class DeviceRegistrationResponse(BaseModel):
     created_at: UTCDateTime = Field(..., description="Registration timestamp")
     is_new: bool = Field(..., description="True if new device, False if updated existing")
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
#505 step 5. Migrates 6 deprecated `class Config:` blocks (api_key.py ×4, device.py ×2) to `model_config = ConfigDict(...)`. Clears the Pydantic 2.13 `PydanticDeprecatedSince20` warnings now that prod runs pydantic 2.13. Functionally equivalent.

Also re-enabled the **CI** workflow (was `disabled_manually` since May; this is the first run since) — #505 step 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)