### PR TITLE
fix(frontend): restore green lint (eslint 9 + resolve 31 exposed errors)

### DIFF
--- a/frontend/app/status/page.tsx
+++ b/frontend/app/status/page.tsx
@@ -27,7 +27,13 @@ import {
 import { parseApiDate, formatRelative } from '@/lib/datetime';
 
 import { apiClient } from '@/lib/api-client';
-import type { SystemHealth, LogEntry, LogsResponse } from '@/types/monitoring';
+import type {
+  SystemHealth,
+  LogEntry,
+  LogsResponse,
+  AIResilienceData,
+  CircuitBreakerStatus,
+} from '@/types/monitoring';
 import { useAuth } from '@/contexts/AuthContext';
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -55,22 +61,11 @@ export default function StatusPage() {
   // AI Resilience reset tracking
   const [lastCircuitBreakerReset, setLastCircuitBreakerReset] = useState<string | null>(null);
 
+  // AI Resilience (Circuit Breaker) Status
+  const [aiResilience, setAiResilience] = useState<AIResilienceData | null>(null);
+
   const auth = useAuth();
   const isAdmin = auth.isAdmin;
-
-  // Load data on mount and set up refresh interval
-  useEffect(() => {
-    loadData();
-    const interval = setInterval(loadData, 30000); // Refresh every 30s
-    return () => clearInterval(interval);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // Reload logs when level filter changes
-  useEffect(() => {
-    loadLogs();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [logLevel]);
 
   const loadData = async () => {
     setIsRefreshing(true);
@@ -119,6 +114,20 @@ export default function StatusPage() {
       setLogs([]);
     }
   };
+
+  // Load data on mount and set up refresh interval
+  useEffect(() => {
+    loadData();
+    const interval = setInterval(loadData, 30000); // Refresh every 30s
+    return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Reload logs when level filter changes
+  useEffect(() => {
+    loadLogs();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [logLevel]);
 
   const handleDownloadLogs = async () => {
     // TODO: Implement log download API endpoint (tracked in backlog)
@@ -179,9 +188,6 @@ export default function StatusPage() {
       description: 'Vision API providers',
     },
   ];
-
-  // AI Resilience (Circuit Breaker) Status
-  const [aiResilience, setAiResilience] = useState<any>(null);
 
   useEffect(() => {
     const loadResilience = async () => {
@@ -334,15 +340,16 @@ export default function StatusPage() {
 
           <CardContent>
             <div className="flex flex-wrap gap-3">
-              {Object.entries(aiResilience).map(([name, status]: [string, any]) => {
-                if (!status) return null;
-                const color = status.state === 'closed' ? 'bg-green-500' : 
-                             status.state === 'open' ? 'bg-red-500' : 'bg-yellow-500';
+              {Object.entries(aiResilience).map(([name, status]) => {
+                if (!status || typeof status !== 'object' || !('state' in status)) return null;
+                const { state } = status as CircuitBreakerStatus;
+                const color = state === 'closed' ? 'bg-green-500' :
+                             state === 'open' ? 'bg-red-500' : 'bg-yellow-500';
                 return (
                   <div key={name} className="flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm">
                     <span className="font-medium capitalize">{name}</span>
                     <div className={`h-2 w-2 rounded-full ${color}`} />
-                    <span className="text-xs text-muted-foreground capitalize">{status.state}</span>
+                    <span className="text-xs text-muted-foreground capitalize">{state}</span>
                   </div>
                 );
               })}

--- a/frontend/components/dashboard/AICostTrendsCard.tsx
+++ b/frontend/components/dashboard/AICostTrendsCard.tsx
@@ -15,6 +15,7 @@ import {
   ResponsiveContainer,
   CartesianGrid,
 } from 'recharts';
+import type { AICostTrendPoint } from '@/types/monitoring';
 
 interface AICostTrendsCardProps {
   title?: string;
@@ -30,7 +31,7 @@ export function AICostTrendsCard({
   bucket = 'day',
 }: AICostTrendsCardProps) {
   const [selectedDays, setSelectedDays] = useState(daysBack);
-  const [trends, setTrends] = useState<any[]>([]);
+  const [trends, setTrends] = useState<AICostTrendPoint[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [metric, setMetric] = useState<'cost' | 'tokens'>('cost'); // only used in full variant
 

--- a/frontend/components/dashboard/HotActivityCard.tsx
+++ b/frontend/components/dashboard/HotActivityCard.tsx
@@ -14,6 +14,7 @@ import {
   Activity,
   ArrowRight,
 } from 'lucide-react';
+import type { HotActivityData, HotCamera, HotEntity } from '@/types/monitoring';
 
 interface HotActivityCardProps {
   title?: string;
@@ -31,7 +32,7 @@ export function HotActivityCard({
   variant = 'full',
 }: HotActivityCardProps) {
   // Data and filter state
-  const [hotData, setHotData] = useState<any>(null);
+  const [hotData, setHotData] = useState<HotActivityData | null>(null);
   const [hotMinScore, setHotMinScore] = useState<number | ''>('');
   const [hotMinCameraScore, setHotMinCameraScore] = useState<number | ''>('');
   const [hotOnlyNew, setHotOnlyNew] = useState<boolean>(false);
@@ -67,7 +68,7 @@ export function HotActivityCard({
   const loadHotActivity = async () => {
     setIsLoadingHot(true);
     try {
-      const params: any = { limit };
+      const params: NonNullable<Parameters<typeof apiClient.getAIProcessingHot>[0]> = { limit };
       if (hotMinScore !== '') params.min_score = Number(hotMinScore);
       if (hotMinCameraScore !== '') params.min_camera_score = Number(hotMinCameraScore);
       if (hotOnlyNew) params.entity_is_new = true;
@@ -95,7 +96,7 @@ export function HotActivityCard({
     if (!hotData) return null;
     const camCount = hotData.hot_cameras?.length || 0;
     const entCount = hotData.top_recent_entities?.length || 0;
-    const newCount = (hotData.top_recent_entities || []).filter((e: any) => e.is_new).length;
+    const newCount = (hotData.top_recent_entities || []).filter((e) => e.is_new).length;
     const parts = [
       `${camCount} camera${camCount === 1 ? '' : 's'}`,
       `${entCount} ${entCount === 1 ? 'entity' : 'entities'}`,
@@ -110,7 +111,7 @@ export function HotActivityCard({
 
   // --- Live updates via hot-only WebSocket ---
   const buildCurrentFilters = () => {
-    const filters: Record<string, any> = {};
+    const filters: Record<string, number | boolean> = {};
     if (hotMinScore !== '') filters.min_score = Number(hotMinScore);
     if (hotMinCameraScore !== '') filters.min_camera_score = Number(hotMinCameraScore);
     if (hotOnlyNew) filters.entity_is_new = true;
@@ -359,7 +360,7 @@ export function HotActivityCard({
                 </div>
                 {hotData.hot_cameras?.length ? (
                   <ul className="space-y-1 text-sm">
-                    {hotData.hot_cameras.slice(0, displayLimit).map((cam: any, idx: number) => (
+                    {hotData.hot_cameras.slice(0, displayLimit).map((cam: HotCamera, idx: number) => (
                       <li key={idx} className="flex justify-between border-b pb-1">
                         <span>{cam.name || cam.camera_id}</span>
                         <span className="text-muted-foreground tabular-nums">
@@ -382,7 +383,7 @@ export function HotActivityCard({
                 </div>
                 {hotData.top_recent_entities?.length ? (
                   <ul className="space-y-1 text-sm">
-                    {hotData.top_recent_entities.slice(0, displayLimit).map((ent: any, idx: number) => (
+                    {hotData.top_recent_entities.slice(0, displayLimit).map((ent: HotEntity, idx: number) => (
                       <li key={idx} className="flex justify-between border-b pb-1">
                         <span>
                           {ent.name || ent.entity_id}

--- a/frontend/components/dashboard/RecentProcessingActivityCard.tsx
+++ b/frontend/components/dashboard/RecentProcessingActivityCard.tsx
@@ -7,6 +7,7 @@ import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/com
 import { Button } from '@/components/ui/button';
 import { RefreshCw, Clock, AlertTriangle, CheckCircle2, Pause, XCircle, ArrowRight } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
+import type { AIProcessingRecord } from '@/types/monitoring';
 
 interface RecentProcessingActivityCardProps {
   title?: string;
@@ -19,7 +20,7 @@ export function RecentProcessingActivityCard({
   variant = 'full',
   limit = variant === 'mini' ? 8 : 20,
 }: RecentProcessingActivityCardProps) {
-  const [records, setRecords] = useState<any[]>([]);
+  const [records, setRecords] = useState<AIProcessingRecord[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isLiveConnected, setIsLiveConnected] = useState(false);
@@ -32,7 +33,7 @@ export function RecentProcessingActivityCard({
     let skipped = 0;
     let errors = 0;
 
-    records.forEach((r: any) => {
+    records.forEach((r) => {
       if (r.analysis_skipped) {
         skipped++;
       } else if (r.success === false) {
@@ -55,8 +56,8 @@ export function RecentProcessingActivityCard({
     if (records.length < 2) return null;
 
     const timestamps = records
-      .map((r: any) => r.timestamp)
-      .filter((t: number) => typeof t === 'number');
+      .map((r) => r.timestamp)
+      .filter((t): t is number => typeof t === 'number');
 
     if (timestamps.length < 2) return null;
 
@@ -81,8 +82,11 @@ export function RecentProcessingActivityCard({
         setRecords(newRecords);
       } else {
         // Merge without duplicates (simple approach for manual refresh)
-        const existingIds = new Set(records.map((r: any) => r.timestamp + r.camera_id));
-        const merged = [...newRecords.filter((r: any) => !existingIds.has(r.timestamp + r.camera_id)), ...records];
+        const existingIds = new Set(records.map((r) => `${r.timestamp}-${r.camera_id}`));
+        const merged = [
+          ...newRecords.filter((r) => !existingIds.has(`${r.timestamp}-${r.camera_id}`)),
+          ...records,
+        ];
         setRecords(merged.slice(0, limit));
       }
     } catch (err) {
@@ -169,7 +173,7 @@ export function RecentProcessingActivityCard({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [limit]);
 
-  const getStatusInfo = (record: any) => {
+  const getStatusInfo = (record: AIProcessingRecord) => {
     if (record.analysis_skipped) {
       return {
         icon: <Pause className="h-4 w-4" />,
@@ -194,12 +198,12 @@ export function RecentProcessingActivityCard({
     };
   };
 
-  const formatCost = (cost?: number) => {
+  const formatCost = (cost?: number | null) => {
     if (cost == null) return '';
     return `$${cost.toFixed(4)}`;
   };
 
-  const formatLatency = (ms?: number) => {
+  const formatLatency = (ms?: number | null) => {
     if (ms == null) return '';
     return `${Math.round(ms)}ms`;
   };
@@ -300,7 +304,7 @@ export function RecentProcessingActivityCard({
         {/* Main List */}
         {!error && records.length > 0 && (
           <div className="space-y-2">
-            {records.map((record: any) => {
+            {records.map((record) => {
               const status = getStatusInfo(record);
               const time = record.timestamp
                 ? formatDistanceToNow(new Date(record.timestamp * 1000), { addSuffix: true })

--- a/frontend/components/settings/AIResilienceSettings.tsx
+++ b/frontend/components/settings/AIResilienceSettings.tsx
@@ -10,41 +10,11 @@ import { Badge } from '@/components/ui/badge';
 import { toast } from 'sonner';
 import { Loader2, RefreshCw, Save, RotateCcw } from 'lucide-react';
 import { formatRelative } from '@/lib/datetime';
-
-interface CircuitBreakerConfig {
-  failure_threshold: number;
-  recovery_timeout: number;
-  half_open_max_calls: number;
-  failure_rate_threshold: number;
-  minimum_calls_in_window: number;
-  window_duration_seconds: number;
-}
-
-interface CircuitBreakerStatus {
-  provider: string;
-  config: CircuitBreakerConfig;
-  state: 'closed' | 'open' | 'half_open';
-  failure_count: number;
-  current_failure_rate: number | null;
-  recent_window_size: number;
-  last_failure_time: string | null;
-  recent_transitions?: Array<{
-    timestamp: number;
-    from_state?: string;
-    to_state?: string;
-    reason?: string;
-  }>;
-}
-
-interface AIResilienceData {
-  default: CircuitBreakerStatus;
-  openai?: CircuitBreakerStatus;
-  grok?: CircuitBreakerStatus;
-  claude?: CircuitBreakerStatus;
-  gemini?: CircuitBreakerStatus;
-}
-
-const PROVIDERS = ['default', 'openai', 'grok', 'claude', 'gemini'] as const;
+import type {
+  CircuitBreakerConfig,
+  CircuitBreakerStatus,
+  AIResilienceData,
+} from '@/types/monitoring';
 
 const STATE_COLORS = {
   closed: 'bg-green-100 text-green-800 border-green-200',
@@ -58,8 +28,196 @@ const STATE_LABELS = {
   half_open: 'Half-Open (Testing)',
 };
 
+interface ProviderCardProps {
+  provider: string;
+  status?: CircuitBreakerStatus;
+  saving: string | null;
+  resetting: string | null;
+  onSave: (provider: string, config: CircuitBreakerConfig) => void;
+  onReset: (provider: string) => void;
+}
+
+function ProviderCard({ provider, status, saving, resetting, onSave, onReset }: ProviderCardProps) {
+  // Seed the editable form once from the initial status. Subsequent refetches do
+  // not clobber in-progress edits — this matches the original render-helper, where
+  // useState(status.config) only applied the seed on first mount of each card.
+  const [localConfig, setLocalConfig] = useState<CircuitBreakerConfig | null>(status?.config ?? null);
+
+  if (!status || !localConfig) return null;
+
+  const hasChanges = JSON.stringify(localConfig) !== JSON.stringify(status.config);
+
+  return (
+    <Card key={provider} className="mb-6">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <div>
+          <CardTitle className="capitalize">{provider} Circuit Breaker</CardTitle>
+          <CardDescription>Failure detection and recovery settings</CardDescription>
+        </div>
+        <Badge className={STATE_COLORS[status.state]}>
+          {STATE_LABELS[status.state]}
+        </Badge>
+      </CardHeader>
+
+      <CardContent className="space-y-6">
+        {/* Live Stats */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+          <div>
+            <div className="text-muted-foreground">State</div>
+            <div className="font-medium capitalize">{status.state}</div>
+          </div>
+          <div>
+            <div className="text-muted-foreground">Failure Count</div>
+            <div className="font-medium">{status.failure_count}</div>
+          </div>
+          <div>
+            <div className="text-muted-foreground">Failure Rate</div>
+            <div className="font-medium">
+              {status.current_failure_rate !== null
+                ? `${(status.current_failure_rate * 100).toFixed(1)}%`
+                : 'N/A'}
+            </div>
+          </div>
+          <div>
+            <div className="text-muted-foreground">Window Size</div>
+            <div className="font-medium">{status.recent_window_size} calls</div>
+          </div>
+        </div>
+
+        {/* Config Form */}
+        <div className="space-y-4">
+          <div className="text-sm font-medium">Configuration</div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <Label>Failure Threshold (consecutive)</Label>
+              <Input
+                type="number"
+                value={localConfig.failure_threshold}
+                onChange={(e) => setLocalConfig({ ...localConfig, failure_threshold: parseInt(e.target.value) || 5 })}
+              />
+            </div>
+
+            <div>
+              <Label>Recovery Timeout (seconds)</Label>
+              <Input
+                type="number"
+                step="1"
+                value={localConfig.recovery_timeout}
+                onChange={(e) => setLocalConfig({ ...localConfig, recovery_timeout: parseFloat(e.target.value) || 90 })}
+              />
+            </div>
+
+            <div>
+              <Label>Failure Rate Threshold</Label>
+              <Input
+                type="number"
+                step="0.05"
+                value={localConfig.failure_rate_threshold}
+                onChange={(e) => setLocalConfig({ ...localConfig, failure_rate_threshold: parseFloat(e.target.value) || 0.5 })}
+              />
+            </div>
+
+            <div>
+              <Label>Window Duration (seconds)</Label>
+              <Input
+                type="number"
+                value={localConfig.window_duration_seconds}
+                onChange={(e) => setLocalConfig({ ...localConfig, window_duration_seconds: parseFloat(e.target.value) || 60 })}
+              />
+            </div>
+
+            <div>
+              <Label>Min Calls in Window</Label>
+              <Input
+                type="number"
+                value={localConfig.minimum_calls_in_window}
+                onChange={(e) => setLocalConfig({ ...localConfig, minimum_calls_in_window: parseInt(e.target.value) || 6 })}
+              />
+            </div>
+
+            <div>
+              <Label>Half-Open Max Calls</Label>
+              <Input
+                type="number"
+                value={localConfig.half_open_max_calls}
+                onChange={(e) => setLocalConfig({ ...localConfig, half_open_max_calls: parseInt(e.target.value) || 1 })}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="flex gap-2 pt-2">
+          <Button
+            onClick={() => onSave(provider, localConfig)}
+            disabled={!hasChanges || saving === provider}
+            className="flex-1"
+          >
+            {saving === provider ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Save className="mr-2 h-4 w-4" />
+            )}
+            Save Configuration
+          </Button>
+
+          <Button
+            variant="outline"
+            onClick={() => onReset(provider)}
+            disabled={resetting === provider}
+          >
+            {resetting === provider ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <RotateCcw className="mr-2 h-4 w-4" />
+            )}
+            Reset Breaker
+          </Button>
+        </div>
+
+        {hasChanges && (
+          <p className="text-xs text-muted-foreground">You have unsaved changes.</p>
+        )}
+
+        {/* Recent Transitions History */}
+        {status.recent_transitions && status.recent_transitions.length > 0 && (
+          <details className="mt-4">
+            <summary className="cursor-pointer text-sm font-medium text-muted-foreground hover:text-foreground">
+              Recent Transitions ({status.recent_transitions.length})
+            </summary>
+            <div className="mt-2 max-h-48 overflow-auto rounded-md border bg-muted/30 p-3 text-xs">
+              <table className="w-full">
+                <thead>
+                  <tr className="text-left text-muted-foreground">
+                    <th className="pb-1">Time</th>
+                    <th className="pb-1">From → To</th>
+                    <th className="pb-1">Reason</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {status.recent_transitions.slice(0, 8).map((t, idx) => (
+                    <tr key={idx} className="border-t">
+                      <td className="py-1 font-mono text-[10px]">
+                        {new Date(t.timestamp * 1000).toLocaleTimeString()}
+                      </td>
+                      <td className="py-1">
+                        <span className="font-medium">{t.from_state}</span> → <span className="font-medium">{t.to_state}</span>
+                      </td>
+                      <td className="py-1 text-muted-foreground">{t.reason || "—"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </details>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 export function AIResilienceSettings() {
-  const [data, setData] = useState<any>(null);
+  const [data, setData] = useState<AIResilienceData | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState<string | null>(null);
   const [resetting, setResetting] = useState<string | null>(null);
@@ -91,9 +249,9 @@ export function AIResilienceSettings() {
       await apiClient.updateAIResilienceConfig(provider, config);
       toast.success(`Circuit breaker config for ${provider} saved`);
       await fetchStatus();
-    } catch (error: any) {
+    } catch (error) {
       toast.error(`Failed to save config for ${provider}`, {
-        description: error?.message || 'Unknown error',
+        description: error instanceof Error ? error.message : 'Unknown error',
       });
     } finally {
       setSaving(null);
@@ -140,181 +298,17 @@ export function AIResilienceSettings() {
     return <div className="text-red-500">Failed to load AI Resilience data.</div>;
   }
 
-  const renderProviderCard = (provider: string, status?: CircuitBreakerStatus) => {
-    if (!status) return null;
-
-    const [localConfig, setLocalConfig] = useState<CircuitBreakerConfig>(status.config);
-
-    const hasChanges = JSON.stringify(localConfig) !== JSON.stringify(status.config);
-
-    return (
-      <Card key={provider} className="mb-6">
-        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <div>
-            <CardTitle className="capitalize">{provider} Circuit Breaker</CardTitle>
-            <CardDescription>Failure detection and recovery settings</CardDescription>
-          </div>
-          <Badge className={STATE_COLORS[status.state]}>
-            {STATE_LABELS[status.state]}
-          </Badge>
-        </CardHeader>
-
-        <CardContent className="space-y-6">
-          {/* Live Stats */}
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-            <div>
-              <div className="text-muted-foreground">State</div>
-              <div className="font-medium capitalize">{status.state}</div>
-            </div>
-            <div>
-              <div className="text-muted-foreground">Failure Count</div>
-              <div className="font-medium">{status.failure_count}</div>
-            </div>
-            <div>
-              <div className="text-muted-foreground">Failure Rate</div>
-              <div className="font-medium">
-                {status.current_failure_rate !== null 
-                  ? `${(status.current_failure_rate * 100).toFixed(1)}%` 
-                  : 'N/A'}
-              </div>
-            </div>
-            <div>
-              <div className="text-muted-foreground">Window Size</div>
-              <div className="font-medium">{status.recent_window_size} calls</div>
-            </div>
-          </div>
-
-          {/* Config Form */}
-          <div className="space-y-4">
-            <div className="text-sm font-medium">Configuration</div>
-            
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <Label>Failure Threshold (consecutive)</Label>
-                <Input
-                  type="number"
-                  value={localConfig.failure_threshold}
-                  onChange={(e) => setLocalConfig({ ...localConfig, failure_threshold: parseInt(e.target.value) || 5 })}
-                />
-              </div>
-
-              <div>
-                <Label>Recovery Timeout (seconds)</Label>
-                <Input
-                  type="number"
-                  step="1"
-                  value={localConfig.recovery_timeout}
-                  onChange={(e) => setLocalConfig({ ...localConfig, recovery_timeout: parseFloat(e.target.value) || 90 })}
-                />
-              </div>
-
-              <div>
-                <Label>Failure Rate Threshold</Label>
-                <Input
-                  type="number"
-                  step="0.05"
-                  value={localConfig.failure_rate_threshold}
-                  onChange={(e) => setLocalConfig({ ...localConfig, failure_rate_threshold: parseFloat(e.target.value) || 0.5 })}
-                />
-              </div>
-
-              <div>
-                <Label>Window Duration (seconds)</Label>
-                <Input
-                  type="number"
-                  value={localConfig.window_duration_seconds}
-                  onChange={(e) => setLocalConfig({ ...localConfig, window_duration_seconds: parseFloat(e.target.value) || 60 })}
-                />
-              </div>
-
-              <div>
-                <Label>Min Calls in Window</Label>
-                <Input
-                  type="number"
-                  value={localConfig.minimum_calls_in_window}
-                  onChange={(e) => setLocalConfig({ ...localConfig, minimum_calls_in_window: parseInt(e.target.value) || 6 })}
-                />
-              </div>
-
-              <div>
-                <Label>Half-Open Max Calls</Label>
-                <Input
-                  type="number"
-                  value={localConfig.half_open_max_calls}
-                  onChange={(e) => setLocalConfig({ ...localConfig, half_open_max_calls: parseInt(e.target.value) || 1 })}
-                />
-              </div>
-            </div>
-          </div>
-
-          <div className="flex gap-2 pt-2">
-            <Button
-              onClick={() => handleSave(provider, localConfig)}
-              disabled={!hasChanges || saving === provider}
-              className="flex-1"
-            >
-              {saving === provider ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <Save className="mr-2 h-4 w-4" />
-              )}
-              Save Configuration
-            </Button>
-
-            <Button
-              variant="outline"
-              onClick={() => handleReset(provider)}
-              disabled={resetting === provider}
-            >
-              {resetting === provider ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <RotateCcw className="mr-2 h-4 w-4" />
-              )}
-              Reset Breaker
-            </Button>
-          </div>
-
-          {hasChanges && (
-            <p className="text-xs text-muted-foreground">You have unsaved changes.</p>
-          )}
-
-          {/* Recent Transitions History */}
-          {status.recent_transitions && status.recent_transitions.length > 0 && (
-            <details className="mt-4">
-              <summary className="cursor-pointer text-sm font-medium text-muted-foreground hover:text-foreground">
-                Recent Transitions ({status.recent_transitions.length})
-              </summary>
-              <div className="mt-2 max-h-48 overflow-auto rounded-md border bg-muted/30 p-3 text-xs">
-                <table className="w-full">
-                  <thead>
-                    <tr className="text-left text-muted-foreground">
-                      <th className="pb-1">Time</th>
-                      <th className="pb-1">From → To</th>
-                      <th className="pb-1">Reason</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {status.recent_transitions.slice(0, 8).map((t: any, idx: number) => (
-                      <tr key={idx} className="border-t">
-                        <td className="py-1 font-mono text-[10px]">
-                          {new Date(t.timestamp * 1000).toLocaleTimeString()}
-                        </td>
-                        <td className="py-1">
-                          <span className="font-medium">{t.from_state}</span> → <span className="font-medium">{t.to_state}</span>
-                        </td>
-                        <td className="py-1 text-muted-foreground">{t.reason || "—"}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </details>
-          )}
-        </CardContent>
-      </Card>
-    );
-  };
+  const renderCard = (provider: string, status?: CircuitBreakerStatus) => (
+    <ProviderCard
+      key={provider}
+      provider={provider}
+      status={status}
+      saving={saving}
+      resetting={resetting}
+      onSave={handleSave}
+      onReset={handleReset}
+    />
+  );
 
   return (
     <div className="space-y-6">
@@ -347,11 +341,11 @@ export function AIResilienceSettings() {
         </Button>
       </div>
 
-      {renderProviderCard('default', data.default)}
-      {renderProviderCard('openai', data.openai)}
-      {renderProviderCard('grok', data.grok)}
-      {renderProviderCard('claude', data.claude)}
-      {renderProviderCard('gemini', data.gemini)}
+      {renderCard('default', data.default)}
+      {renderCard('openai', data.openai)}
+      {renderCard('grok', data.grok)}
+      {renderCard('claude', data.claude)}
+      {renderCard('gemini', data.gemini)}
 
       <div className="flex justify-end">
         <Button variant="outline" onClick={fetchStatus}>

--- a/frontend/components/settings/PromptRefinementModal.tsx
+++ b/frontend/components/settings/PromptRefinementModal.tsx
@@ -40,25 +40,6 @@ export function PromptRefinementModal({
   const [editedPrompt, setEditedPrompt] = useState('');
   const [error, setError] = useState<string | null>(null);
 
-  // Reset state when modal opens
-  const handleOpenChange = useCallback((newOpen: boolean) => {
-    if (newOpen) {
-      // Modal opening - reset state and start refinement
-      setRefinementResult(null);
-      setEditedPrompt('');
-      setError(null);
-      // Auto-start refinement when modal opens
-      handleRefine(currentPrompt);
-    } else {
-      // Modal closing - reset state
-      setRefinementResult(null);
-      setEditedPrompt('');
-      setError(null);
-      setIsLoading(false);
-    }
-    onOpenChange(newOpen);
-  }, [currentPrompt, onOpenChange]);
-
   // Call the refinement API
   const handleRefine = async (promptToRefine: string) => {
     setIsLoading(true);
@@ -92,6 +73,25 @@ export function PromptRefinementModal({
       setIsLoading(false);
     }
   };
+
+  // Reset state when modal opens
+  const handleOpenChange = useCallback((newOpen: boolean) => {
+    if (newOpen) {
+      // Modal opening - reset state and start refinement
+      setRefinementResult(null);
+      setEditedPrompt('');
+      setError(null);
+      // Auto-start refinement when modal opens
+      handleRefine(currentPrompt);
+    } else {
+      // Modal closing - reset state
+      setRefinementResult(null);
+      setEditedPrompt('');
+      setError(null);
+      setIsLoading(false);
+    }
+    onOpenChange(newOpen);
+  }, [currentPrompt, onOpenChange]);
 
   // Handle resubmit with edited prompt
   const handleResubmit = () => {

--- a/frontend/components/setup/SetupWizard.tsx
+++ b/frontend/components/setup/SetupWizard.tsx
@@ -150,11 +150,6 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
   const [savingProvider, setSavingProvider] = useState<AIProvider | null>(null);
   const [configuredProviders, setConfiguredProviders] = useState<Set<AIProvider>>(new Set());
 
-  // Load existing AI provider status on mount
-  useEffect(() => {
-    loadAIProvidersStatus();
-  }, []);
-
   const loadAIProvidersStatus = async () => {
     try {
       const response = await apiClient.settings.getAIProvidersStatus();
@@ -174,6 +169,11 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
       console.error('Failed to load AI providers status:', error);
     }
   };
+
+  // Load existing AI provider status on mount
+  useEffect(() => {
+    loadAIProvidersStatus();
+  }, []);
 
   const currentStepData = SETUP_STEPS[currentStep];
   const progress = ((currentStep + 1) / SETUP_STEPS.length) * 100;

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -69,6 +69,12 @@ import type {
   LogsResponse,
   LogsQueryParams,
   LogFilesResponse,
+  AIResilienceData,
+  AIProcessingRecord,
+  HotCamera,
+  HotEntity,
+  CircuitBreakerConfig,
+  CircuitBreakerStatus,
 } from '@/types/monitoring';
 import type {
   IUser,
@@ -1313,11 +1319,14 @@ export const apiClient = {
   },
 
   // AI Resilience / Circuit Breakers (Phase A - A.5)
-  getAIResilience: async (): Promise<any> => {
+  getAIResilience: async (): Promise<AIResilienceData> => {
     return apiFetch('/system/ai-resilience');
   },
 
-  updateAIResilienceConfig: async (provider: string, config: any): Promise<any> => {
+  updateAIResilienceConfig: async (
+    provider: string,
+    config: CircuitBreakerConfig,
+  ): Promise<CircuitBreakerStatus> => {
     return apiFetch(`/system/ai-resilience/${provider}`, {
       method: 'PUT',
       body: JSON.stringify(config),
@@ -1343,9 +1352,9 @@ export const apiClient = {
     entity_types?: string;
   }): Promise<{
     status: string;
-    hot_cameras: any[];
-    top_recent_entities: any[];
-    filters_applied: Record<string, any>;
+    hot_cameras: HotCamera[];
+    top_recent_entities: HotEntity[];
+    filters_applied: Record<string, unknown>;
   }> => {
     const query = new URLSearchParams();
     if (params) {
@@ -1367,7 +1376,7 @@ export const apiClient = {
     limit?: number;
   }): Promise<{
     status: string;
-    recent_activity: any[];
+    recent_activity: AIProcessingRecord[];
     count: number;
     limit: number;
   }> => {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -59,7 +59,7 @@
         "@vitejs/plugin-react": "^6.0.2",
         "@vitest/coverage-v8": "^4.1.6",
         "axe-core": "^4.11.0",
-        "eslint": "^10",
+        "eslint": "^9",
         "eslint-config-next": "16.2.6",
         "jest-axe": "^10.0.0",
         "jsdom": "^29.1.1",
@@ -699,68 +699,167 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
-      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.5",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^10.2.4"
+        "minimatch": "^3.1.5"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1"
+        "@eslint/core": "^0.17.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
-      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@exodus/bytes": {
@@ -3864,13 +3963,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/esrecurse": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4729,9 +4821,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4794,6 +4886,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
@@ -5199,6 +5298,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
@@ -5979,30 +6088,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
-      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
-        "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.2",
-        "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.2.0",
-        "esquery": "^1.7.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -6012,7 +6124,8 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -6020,7 +6133,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -6352,19 +6465,17 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@types/esrecurse": "^4.3.1",
-        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -6383,19 +6494,76 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.16.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -6820,6 +6988,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globalthis": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
@@ -7026,6 +7207,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -7918,6 +8116,29 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsdom": {
       "version": "29.1.1",
@@ -8871,6 +9092,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
@@ -9386,6 +9620,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -9985,6 +10229,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/styled-jsx": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,7 +70,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/coverage-v8": "^4.1.6",
     "axe-core": "^4.11.0",
-    "eslint": "^10",
+    "eslint": "^9",
     "eslint-config-next": "16.2.6",
     "jest-axe": "^10.0.0",
     "jsdom": "^29.1.1",

--- a/frontend/types/monitoring.ts
+++ b/frontend/types/monitoring.ts
@@ -104,3 +104,112 @@ export interface StatusPageData {
   events: EventMetrics;
   ai: AIMetrics;
 }
+
+/**
+ * A single recognized-entity reference attached to an AI processing record
+ * (either the early/fast pass or the final pass).
+ */
+export interface AIProcessingEntityRef {
+  entity_id?: string;
+  entity_name?: string | null;
+  is_new?: boolean;
+}
+
+/**
+ * One entry from the AI processing coordinator ring buffer
+ * (`/system/ai-processing-recent` → `recent_activity[]`, also streamed via SSE).
+ */
+export interface AIProcessingRecord {
+  timestamp: number;
+  camera_id?: string;
+  provider?: string | null;
+  description?: string | null;
+  success?: boolean;
+  analysis_skipped?: boolean;
+  analysis_skipped_reason?: string | null;
+  low_confidence?: boolean;
+  ocr_used?: boolean;
+  regenerated?: boolean;
+  ai_cost?: number | null;
+  ai_response_time_ms?: number | null;
+  error?: string | null;
+  entity_early?: AIProcessingEntityRef | null;
+  entity_final?: AIProcessingEntityRef | null;
+}
+
+/** A trending camera surfaced by the coordinator hot lists. */
+export interface HotCamera {
+  camera_id?: string;
+  name?: string | null;
+  score?: number;
+  count?: number;
+}
+
+/** A trending recognized entity surfaced by the coordinator hot lists. */
+export interface HotEntity {
+  entity_id?: string;
+  name?: string | null;
+  score?: number;
+  is_new?: boolean;
+  target?: string;
+}
+
+/**
+ * Response shape for `/system/ai-processing-hot` and the matching hot-update
+ * WebSocket/SSE payloads.
+ */
+export interface HotActivityData {
+  status?: string;
+  hot_cameras: HotCamera[];
+  top_recent_entities: HotEntity[];
+  filters_applied?: Record<string, unknown>;
+}
+
+/** One bucketed point from `/system/ai-cost-trends` → `trends[]`. */
+export interface AICostTrendPoint {
+  bucket: string;
+  calls: number;
+  total_cost: number;
+  total_tokens: number;
+  avg_response_time_ms: number | null;
+}
+
+/** Circuit-breaker tuning knobs for a single AI provider. */
+export interface CircuitBreakerConfig {
+  failure_threshold: number;
+  recovery_timeout: number;
+  half_open_max_calls: number;
+  failure_rate_threshold: number;
+  minimum_calls_in_window: number;
+  window_duration_seconds: number;
+}
+
+/** Live circuit-breaker status for a single AI provider. */
+export interface CircuitBreakerStatus {
+  provider: string;
+  config: CircuitBreakerConfig;
+  state: 'closed' | 'open' | 'half_open';
+  failure_count: number;
+  current_failure_rate: number | null;
+  recent_window_size: number;
+  last_failure_time: string | null;
+  recent_transitions?: Array<{
+    timestamp: number;
+    from_state?: string;
+    to_state?: string;
+    reason?: string;
+  }>;
+}
+
+/**
+ * Response shape for `/system/ai-resilience` — per-provider circuit-breaker
+ * status keyed by provider name, plus an optional global last-reset marker.
+ */
+export interface AIResilienceData {
+  default: CircuitBreakerStatus;
+  openai?: CircuitBreakerStatus;
+  grok?: CircuitBreakerStatus;
+  claude?: CircuitBreakerStatus;
+  gemini?: CircuitBreakerStatus;
+  last_reset?: string | null;
+}


### PR DESCRIPTION
#508. Pins `eslint ^10`→`^9` (fixes the ESLint-10 `getFilename` crash) and properly fixes the 31 errors it unmasked (26 `any`→types, 1 rules-of-hooks → extracted `ProviderCard`, 4 TDZ reorderings). `npm run lint` exits 0; `next build` passes; zero `eslint-disable`/`as any`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)