### PR TITLE
fix(protect): doorbell-ring AttributeError (native path) + repair 7 stale test files (#508 chunk 10)

### DIFF
--- a/backend/app/services/protect_event_handler.py
+++ b/backend/app/services/protect_event_handler.py
@@ -809,7 +809,7 @@ class ProtectEventHandler:
                         thumbnail_url=snapshot_result.thumbnail_path,
                         timestamp=snapshot_result.timestamp
                     )
-                    self._trigger_homekit_doorbell(camera.id, generated_event_id)
+                    self.broadcaster.trigger_homekit_doorbell(camera.id, generated_event_id)
 
                 # Track processing time
                 pipeline_start = time.time()

--- a/backend/tests/test_api/test_cameras.py
+++ b/backend/tests/test_api/test_cameras.py
@@ -1492,10 +1492,10 @@ class TestCameraAnalysisModeAPI:
 class TestCameraCaptureAdminActions:
     """Tests for manual enable/disable capture endpoints and health endpoint (#449)"""
 
-    def test_enable_and_disable_capture_endpoints(self, client, db_session):
+    def test_enable_and_disable_capture_endpoints(self, api_client, db_session):
         """Admin can disable and re-enable capture via API."""
         # Create camera
-        create_resp = client.post("/api/v1/cameras", json={
+        create_resp = api_client.post("/api/v1/cameras", json={
             "name": "Admin Action Cam",
             "type": "rtsp",
             "rtsp_url": "rtsp://example.com/stream"
@@ -1504,24 +1504,24 @@ class TestCameraCaptureAdminActions:
         cam_id = create_resp.json()["id"]
 
         # Manually disable
-        disable_resp = client.post(f"/api/v1/cameras/{cam_id}/disable-capture")
+        disable_resp = api_client.post(f"/api/v1/cameras/{cam_id}/disable-capture")
         assert disable_resp.status_code == 200
         assert disable_resp.json()["capture_disabled"] is True
 
         # Health should reflect disabled
-        health_resp = client.get("/api/v1/cameras/health")
+        health_resp = api_client.get("/api/v1/cameras/health")
         assert health_resp.status_code == 200
         health = health_resp.json()
         assert health["disabled"] >= 1
 
         # Re-enable
-        enable_resp = client.post(f"/api/v1/cameras/{cam_id}/enable-capture")
+        enable_resp = api_client.post(f"/api/v1/cameras/{cam_id}/enable-capture")
         assert enable_resp.status_code == 200
         assert enable_resp.json()["capture_disabled"] is False
 
-    def test_health_endpoint_returns_expected_fields(self, client, db_session):
+    def test_health_endpoint_returns_expected_fields(self, api_client, db_session):
         """The dedicated health endpoint returns the expected structure."""
-        resp = client.get("/api/v1/cameras/health")
+        resp = api_client.get("/api/v1/cameras/health")
         assert resp.status_code == 200
         data = resp.json()
 
@@ -1532,10 +1532,10 @@ class TestCameraCaptureAdminActions:
         assert "cameras" in data
         assert isinstance(data["cameras"], dict)
 
-    def test_disable_and_enable_capture_via_api(self, client, db_session):
+    def test_disable_and_enable_capture_via_api(self, api_client, db_session):
         """Admin can disable and re-enable a camera via the new endpoints."""
         # Create a camera
-        create_resp = client.post("/api/v1/cameras", json={
+        create_resp = api_client.post("/api/v1/cameras", json={
             "name": "Policy Test Cam",
             "type": "rtsp",
             "rtsp_url": "rtsp://example.com/stream"
@@ -1544,26 +1544,26 @@ class TestCameraCaptureAdminActions:
         cam_id = create_resp.json()["id"]
 
         # Disable it
-        disable_resp = client.post(f"/api/v1/cameras/{cam_id}/disable-capture")
+        disable_resp = api_client.post(f"/api/v1/cameras/{cam_id}/disable-capture")
         assert disable_resp.status_code == 200
         assert disable_resp.json()["capture_disabled"] is True
 
         # Health should reflect it
-        health = client.get("/api/v1/cameras/health").json()
+        health = api_client.get("/api/v1/cameras/health").json()
         assert health["disabled"] >= 1
 
         # Re-enable it
-        enable_resp = client.post(f"/api/v1/cameras/{cam_id}/enable-capture")
+        enable_resp = api_client.post(f"/api/v1/cameras/{cam_id}/enable-capture")
         assert enable_resp.status_code == 200
         assert enable_resp.json()["capture_disabled"] is False
 
         # Camera should now be eligible to start again
-        health = client.get("/api/v1/cameras/health").json()
+        health = api_client.get("/api/v1/cameras/health").json()
         assert health["disabled"] == 0 or cam_id not in [c for c in health["cameras"] if health["cameras"][c].get("capture_disabled")]
 
-    def test_camera_detail_includes_capture_health_fields(self, client, db_session):
+    def test_camera_detail_includes_capture_health_fields(self, api_client, db_session):
         """GET /cameras/{id} should include capture_disabled and restart_attempts."""
-        create_resp = client.post("/api/v1/cameras", json={
+        create_resp = api_client.post("/api/v1/cameras", json={
             "name": "Detail Health Cam",
             "type": "rtsp",
             "rtsp_url": "rtsp://example.com/stream"
@@ -1571,10 +1571,10 @@ class TestCameraCaptureAdminActions:
         cam_id = create_resp.json()["id"]
 
         # Disable it
-        client.post(f"/api/v1/cameras/{cam_id}/disable-capture")
+        api_client.post(f"/api/v1/cameras/{cam_id}/disable-capture")
 
         # Get detail
-        detail = client.get(f"/api/v1/cameras/{cam_id}").json()
+        detail = api_client.get(f"/api/v1/cameras/{cam_id}").json()
         assert "capture_disabled" in detail
         assert detail["capture_disabled"] is True
         assert "restart_attempts" in detail

--- a/backend/tests/test_api/test_events.py
+++ b/backend/tests/test_api/test_events.py
@@ -2219,7 +2219,7 @@ class TestSignedThumbnailEndpoint:
         mock_service = MagicMock()
         mock_service.verify_signed_url.return_value = True
 
-        with patch("app.services.signed_url_service.get_signed_url_service", return_value=mock_service):
+        with patch("app.services.service_container.get_signed_url_service", return_value=mock_service):
             response = client.get(
                 f"/api/v1/events/{event_id}/thumbnail",
                 params={"signature": signature, "expires": expires}
@@ -2241,7 +2241,7 @@ class TestSignedThumbnailEndpoint:
         mock_service = MagicMock()
         mock_service.verify_signed_url.return_value = False
 
-        with patch("app.services.signed_url_service.get_signed_url_service", return_value=mock_service):
+        with patch("app.services.service_container.get_signed_url_service", return_value=mock_service):
             response = client.get(
                 f"/api/v1/events/{event_id}/thumbnail",
                 params={"signature": invalid_signature, "expires": expires}
@@ -2264,7 +2264,7 @@ class TestSignedThumbnailEndpoint:
         mock_service = MagicMock()
         mock_service.verify_signed_url.return_value = False
 
-        with patch("app.services.signed_url_service.get_signed_url_service", return_value=mock_service):
+        with patch("app.services.service_container.get_signed_url_service", return_value=mock_service):
             response = client.get(
                 f"/api/v1/events/{event_id}/thumbnail",
                 params={"signature": signature, "expires": expires}
@@ -2284,7 +2284,7 @@ class TestSignedThumbnailEndpoint:
         mock_service = MagicMock()
         mock_service.verify_signed_url.return_value = True
 
-        with patch("app.services.signed_url_service.get_signed_url_service", return_value=mock_service):
+        with patch("app.services.service_container.get_signed_url_service", return_value=mock_service):
             response = client.get(
                 "/api/v1/events/nonexistent-event-id/thumbnail",
                 params={"signature": signature, "expires": expires}
@@ -2305,7 +2305,7 @@ class TestSignedThumbnailEndpoint:
         mock_service = MagicMock()
         mock_service.verify_signed_url.return_value = True
 
-        with patch("app.services.signed_url_service.get_signed_url_service", return_value=mock_service):
+        with patch("app.services.service_container.get_signed_url_service", return_value=mock_service):
             response = client.get(
                 f"/api/v1/events/{event_id}/thumbnail",
                 params={"signature": signature, "expires": expires}
@@ -2326,7 +2326,7 @@ class TestSignedThumbnailEndpoint:
         mock_service = MagicMock()
         mock_service.verify_signed_url.return_value = True
 
-        with patch("app.services.signed_url_service.get_signed_url_service", return_value=mock_service):
+        with patch("app.services.service_container.get_signed_url_service", return_value=mock_service):
             response = client.get(
                 f"/api/v1/events/{event_id}/thumbnail",
                 params={"signature": signature, "expires": expires}

--- a/backend/tests/test_services/test_ai_prompt_service.py
+++ b/backend/tests/test_services/test_ai_prompt_service.py
@@ -34,7 +34,7 @@ class TestAIPromptServiceBasic:
     def test_builds_context_string_with_objects_and_audio(self):
         service = AIPromptService(default_prompt="Base prompt")
         prompt, _ = service.select_and_build_prompt(
-            camera_name="Backyard",
+            camera_id="Backyard",
             detected_objects=["person", "package"],
             audio_transcription="Someone is at the door"
         )

--- a/backend/tests/test_services/test_face_detection_service.py
+++ b/backend/tests/test_services/test_face_detection_service.py
@@ -299,12 +299,11 @@ class TestFaceDetectionServiceSingleton:
         """Test that get_face_detection_service returns singleton."""
         from app.services.face_detection_service import (
             get_face_detection_service,
-            _face_detection_service,
+            reset_face_detection_service,
         )
 
-        # Reset singleton for test
-        import app.services.face_detection_service as module
-        module._face_detection_service = None
+        # Reset singleton for test (service now uses the @singleton decorator)
+        reset_face_detection_service()
 
         service1 = get_face_detection_service()
         service2 = get_face_detection_service()

--- a/backend/tests/test_services/test_homekit_doorbell.py
+++ b/backend/tests/test_services/test_homekit_doorbell.py
@@ -312,14 +312,14 @@ class TestProtectEventHandlerDoorbellIntegration:
     """Test protect_event_handler doorbell trigger integration (AC2, AC3)."""
 
     def test_trigger_homekit_doorbell_success(self):
-        """_trigger_homekit_doorbell triggers HomeKit when service is running."""
+        """broadcaster.trigger_homekit_doorbell triggers HomeKit when service is running."""
         with patch.dict("sys.modules", {"app.services.homekit_service": MagicMock()}):
             from app.services.protect_event_handler import ProtectEventHandler
 
             handler = ProtectEventHandler()
 
-            # Patch the import inside the method
-            with patch.object(handler, "_trigger_homekit_doorbell") as mock_trigger:
+            # The doorbell trigger was extracted onto the broadcaster collaborator.
+            with patch.object(handler.broadcaster, "trigger_homekit_doorbell") as mock_trigger:
                 mock_trigger.return_value = True
                 result = mock_trigger("cam-123", "event-456")
                 assert result is True

--- a/backend/tests/test_services/test_vehicle_matching_service.py
+++ b/backend/tests/test_services/test_vehicle_matching_service.py
@@ -202,7 +202,7 @@ class TestVehicleMatchingService:
         mock_vehicle.first_seen_at = datetime.now(timezone.utc)
         mock_vehicle.last_seen_at = datetime.now(timezone.utc)
         mock_vehicle.occurrence_count = 5
-        mock_vehicle.metadata = '{"detected_type": "car", "primary_color": "blue"}'
+        mock_vehicle.entity_metadata = '{"detected_type": "car", "primary_color": "blue"}'
 
         mock_db = MagicMock()
         mock_query = MagicMock()

--- a/backend/tests/test_ssl.py
+++ b/backend/tests/test_ssl.py
@@ -31,13 +31,18 @@ class TestSSLSettings:
         """Test that SSL is disabled by default"""
         from app.core.config import Settings
 
-        # Create settings without SSL env vars
+        # Create settings without SSL env vars. Note: main.py sets a default
+        # SSL_CERT_FILE env var (certifi CA bundle) on import for AI-provider TLS,
+        # so SSL_CERT_FILE/SSL_KEY_FILE are passed explicitly here to assert the
+        # field-level defaults rather than the ambient process environment.
         with patch.dict(os.environ, {}, clear=False):
             # Don't validate cert files for this test
             settings = Settings(
                 _env_file=None,
-                ENCRYPTION_KEY="test-key-must-be-at-least-32-chars-long",
-                JWT_SECRET_KEY="test-jwt-secret-for-testing-must-be-at-least-32-chars-long"
+                ENCRYPTION_KEY="YhLHon9m3QOhb394b-Qa761Vgj9ij3oLlT-moS2oRcg=",
+                JWT_SECRET_KEY="test-jwt-secret-for-testing-must-be-at-least-32-chars-long",
+                SSL_CERT_FILE=None,
+                SSL_KEY_FILE=None
             )
             assert settings.SSL_ENABLED is False
             assert settings.SSL_CERT_FILE is None
@@ -52,7 +57,7 @@ class TestSSLSettings:
 
         settings = Settings(
             _env_file=None,
-            ENCRYPTION_KEY="test-key-must-be-at-least-32-chars-long",
+            ENCRYPTION_KEY="YhLHon9m3QOhb394b-Qa761Vgj9ij3oLlT-moS2oRcg=",
             JWT_SECRET_KEY="test-jwt-secret-for-testing-must-be-at-least-32-chars-long",
             SSL_ENABLED=False
         )
@@ -64,7 +69,7 @@ class TestSSLSettings:
 
         settings = Settings(
             _env_file=None,
-            ENCRYPTION_KEY="test-key-must-be-at-least-32-chars-long",
+            ENCRYPTION_KEY="YhLHon9m3QOhb394b-Qa761Vgj9ij3oLlT-moS2oRcg=",
             JWT_SECRET_KEY="test-jwt-secret-for-testing-must-be-at-least-32-chars-long",
             SSL_ENABLED=True,
             SSL_CERT_FILE=None,
@@ -80,7 +85,7 @@ class TestSSLSettings:
         with pytest.raises(ValidationError) as exc_info:
             Settings(
                 _env_file=None,
-                ENCRYPTION_KEY="test-key-must-be-at-least-32-chars-long",
+                ENCRYPTION_KEY="YhLHon9m3QOhb394b-Qa761Vgj9ij3oLlT-moS2oRcg=",
                 JWT_SECRET_KEY="test-jwt-secret-for-testing-must-be-at-least-32-chars-long",
                 SSL_MIN_VERSION="TLSv1_0"  # Invalid
             )
@@ -93,7 +98,7 @@ class TestSSLSettings:
         # Test TLSv1_2
         settings = Settings(
             _env_file=None,
-            ENCRYPTION_KEY="test-key-must-be-at-least-32-chars-long",
+            ENCRYPTION_KEY="YhLHon9m3QOhb394b-Qa761Vgj9ij3oLlT-moS2oRcg=",
             JWT_SECRET_KEY="test-jwt-secret-for-testing-must-be-at-least-32-chars-long",
             SSL_MIN_VERSION="TLSv1_2"
         )
@@ -102,7 +107,7 @@ class TestSSLSettings:
         # Test TLSv1_3
         settings = Settings(
             _env_file=None,
-            ENCRYPTION_KEY="test-key-must-be-at-least-32-chars-long",
+            ENCRYPTION_KEY="YhLHon9m3QOhb394b-Qa761Vgj9ij3oLlT-moS2oRcg=",
             JWT_SECRET_KEY="test-jwt-secret-for-testing-must-be-at-least-32-chars-long",
             SSL_MIN_VERSION="TLSv1_3"
         )


### PR DESCRIPTION
#508 chunk 10. **Bug #22 (source, live):** `protect_event_handler.py:812` doorbell-ring branch of the native WS path called the removed `_trigger_homekit_doorbell` → `AttributeError` on every real doorbell ring (line 413's parallel branch was already fixed; 812 was missed). Repointed to `broadcaster.trigger_homekit_doorbell`. Tests: ssl 4→19, events 4→6, cameras 4err→4, homekit_doorbell 1→17, vehicle_matching 1→34, face_detection 1→18, ai_prompt_service 1→5. No skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)