### PR TITLE
fix(feedback): compute daily-trend window in UTC, not local server date (bug #23)

### DIFF
--- a/backend/app/api/v1/feedback.py
+++ b/backend/app/api/v1/feedback.py
@@ -190,12 +190,12 @@ async def get_feedback_stats(
             trend_end = end_date
         elif start_date:
             trend_start = start_date
-            trend_end = date.today()
+            trend_end = datetime.now(timezone.utc).date()
         elif end_date:
             trend_start = end_date - timedelta(days=30)
             trend_end = end_date
         else:
-            trend_end = date.today()
+            trend_end = datetime.now(timezone.utc).date()
             trend_start = trend_end - timedelta(days=30)
 
         trend_start_dt = datetime.combine(trend_start, datetime.min.time()).replace(tzinfo=timezone.utc)


### PR DESCRIPTION
**Bug #23 (source, on-theme with the UTC work):** `/api/v1/feedback/stats` built the daily_trend window from `date.today()` (local server date) but compares against UTC-stored `created_at`. When the server is behind UTC and it's past UTC midnight (every US evening), the window upper bound is earlier than `now` in UTC → **today's feedback is silently dropped from the 30-day trend**. Fixed to `datetime.now(timezone.utc).date()`.

Surfaced by the final full-suite remeasure: `test_get_stats_daily_trend` (the single remaining failure, asserting ≥2 daily buckets, got 1) is now green with **no test change** — the assertion caught a real bug. **Full suite: 1 failed → 0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)