### PR TITLE
fix(protect): make camera.analysis_mode authoritative; default multi_frame

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_default_analysis_mode_multi_frame.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_default_analysis_mode_multi_frame.py
@@ -1,0 +1,65 @@
+"""default analysis_mode to multi_frame and backfill existing Protect cameras
+
+The live Protect AI pipeline now treats ``Camera.analysis_mode`` as authoritative
+(it no longer opportunistically upgrades/downgrades based on clip availability).
+To make multi-frame the project default for clip-capable cameras, this migration:
+
+  1. Changes the ``cameras.analysis_mode`` server default to ``'multi_frame'``.
+  2. Backfills existing **Protect** cameras still on ``'single_frame'`` to
+     ``'multi_frame'``.
+
+The backfill is deliberately scoped to ``source_type = 'protect'``. RTSP/USB
+cameras cannot supply a motion clip, so they must remain ``'single_frame'`` —
+flipping them would only force a pointless clip-download attempt that always
+falls back to single-frame. The existing CHECK constraint already restricts the
+column to the three valid modes, so no constraint change is required.
+
+Idempotent: a re-run's UPDATE selects nothing once the rows are already
+multi_frame.
+
+Revision ID: a1b2c3d4e5f6
+Revises: f3a2c1d4e5b6
+Create Date: 2026-06-30
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "f3a2c1d4e5b6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. New rows default to multi_frame at the DB level.
+    with op.batch_alter_table("cameras") as batch_op:
+        batch_op.alter_column(
+            "analysis_mode",
+            existing_type=sa.String(length=20),
+            server_default="multi_frame",
+            existing_nullable=False,
+        )
+
+    # 2. Backfill existing Protect cameras still on the old single_frame default.
+    #    RTSP/USB cameras are intentionally left untouched (no clip source).
+    op.execute(
+        sa.text(
+            "UPDATE cameras SET analysis_mode = 'multi_frame' "
+            "WHERE source_type = 'protect' AND analysis_mode = 'single_frame'"
+        )
+    )
+
+
+def downgrade() -> None:
+    # Revert the server default only. The data backfill is intentionally NOT
+    # reversed: once cameras are multi_frame we cannot know which Protect cameras
+    # were originally single_frame, and reverting blindly would be lossy.
+    with op.batch_alter_table("cameras") as batch_op:
+        batch_op.alter_column(
+            "analysis_mode",
+            existing_type=sa.String(length=20),
+            server_default="single_frame",
+            existing_nullable=False,
+        )

--- a/backend/app/models/camera.py
+++ b/backend/app/models/camera.py
@@ -74,8 +74,11 @@ class Camera(Base):
     protect_camera_type = Column(String(20), nullable=True)  # 'camera', 'doorbell'
     smart_detection_types = Column(Text, nullable=True)  # JSON array: ["person", "vehicle", "package", "animal"]
     is_doorbell = Column(Boolean, default=False, nullable=False)
-    # Phase 3: Analysis mode for AI processing
-    analysis_mode = Column(String(20), default='single_frame', nullable=False, index=True)
+    # Phase 3: Analysis mode for AI processing.
+    # Default is multi_frame (balanced quality/cost) for clip-capable Protect
+    # cameras. RTSP/USB creation explicitly overrides this to single_frame at the
+    # schema layer since they cannot supply a motion clip.
+    analysis_mode = Column(String(20), default='multi_frame', nullable=False, index=True)
     # Phase 4 (P4-5.4): Per-camera custom prompt override based on feedback analysis
     prompt_override = Column(Text, nullable=True)
     # Phase 6 (P6-3.1): Audio stream extraction configuration

--- a/backend/app/services/protect_ai_pipeline.py
+++ b/backend/app/services/protect_ai_pipeline.py
@@ -40,6 +40,7 @@ class ProtectAIPipeline:
 
     def __init__(self):
         self._last_analysis_mode: Optional[str] = None
+        self._last_requested_mode: Optional[str] = None
         self._last_frame_count: Optional[int] = None
         self._last_fallback_reason: Optional[str] = None
         self._last_audio_transcription: Optional[str] = None
@@ -61,6 +62,7 @@ class ProtectAIPipeline:
         """
         # Reset tracking state for this event
         self._last_analysis_mode = None
+        self._last_requested_mode = None
         self._last_frame_count = None
         self._last_fallback_reason = None
         self._last_audio_transcription = None
@@ -77,25 +79,27 @@ class ProtectAIPipeline:
             with get_db_session() as db:
                 await ai_service.load_api_keys_from_db(db)
 
-            # For now, delegate to the existing orchestrator (single frame path)
-            # Full multi-frame + video_native logic can be wired here later
-            # (the original complex logic lived in _submit_to_ai_pipeline)
-
-            # Convert snapshot to the format expected by the orchestrator
-            # (This is a simplified version — the full original logic was very long)
-
-            # Placeholder: In a full extraction we would replicate the fallback chain here
-            # For this micro-step, we delegate the core call
-
-            # TODO: Full extraction of the fallback chain from the old _submit_to_ai_pipeline
+            # The camera's configured analysis_mode is AUTHORITATIVE. The pipeline is
+            # NOT opportunistic: it does not silently upgrade a single_frame camera to
+            # multi_frame just because a clip happens to be present, nor escalate a
+            # multi_frame camera to video_native just because Gemini is available.
+            # An unset/blank mode defaults to multi_frame (the project default for
+            # balanced quality/cost on clip-capable cameras).
+            requested_mode = (getattr(camera, "analysis_mode", None) or "multi_frame")
+            self._last_requested_mode = requested_mode
 
             logger.info(
-                f"Submitting snapshot for AI analysis (camera={camera.name}, type={event_type})",
-                extra={"event_type": "protect_ai_submission"}
+                f"Submitting snapshot for AI analysis "
+                f"(camera={camera.name}, type={event_type}, requested_mode={requested_mode})",
+                extra={
+                    "event_type": "protect_ai_submission",
+                    "requested_mode": requested_mode,
+                    "clip_available": clip_path is not None,
+                }
             )
 
-            # === Video Native path (Gemini native video upload) ===
-            if clip_path:
+            # === Video Native path (only when explicitly configured) ===
+            if requested_mode == "video_native" and clip_path:
                 try:
                     video_result = await self._try_video_native_analysis(
                         clip_path, camera, event_type, is_doorbell_ring
@@ -112,8 +116,9 @@ class ProtectAIPipeline:
                     self._last_fallback_reason = f"video_native_failed:{str(e)}"
                     logger.warning(f"Video native analysis failed for camera '{camera.name}', falling back: {e}")
 
-            # === Multi-frame path (preferred when clip is available) ===
-            if clip_path:
+            # === Multi-frame path (for multi_frame OR as the documented fallback
+            #     step for a configured video_native camera) ===
+            if requested_mode in ("multi_frame", "video_native") and clip_path:
                 try:
                     frames, timestamps = await self._extract_frames_from_clip(clip_path, camera)
                     if frames:
@@ -138,7 +143,17 @@ class ProtectAIPipeline:
                     self._last_fallback_reason = f"multi_frame_failed:{str(e)}"
                     logger.warning(f"Multi-frame analysis failed for camera '{camera.name}', falling back to single frame: {e}")
 
-            # === Single-frame fallback path ===
+            # === Single-frame path ===
+            # Reached when the camera is configured single_frame, when no clip is
+            # available, or after a clip/extraction failure degraded the requested
+            # mode. Record WHY when we degraded below the requested mode so the
+            # silent-fallback can be observed per-event rather than only in logs.
+            if requested_mode != "single_frame" and self._last_fallback_reason is None:
+                self._last_fallback_reason = (
+                    f"{requested_mode}_unavailable:no_clip"
+                    if not clip_path
+                    else f"{requested_mode}_unavailable:no_frames"
+                )
             import base64
             import numpy as np
             from PIL import Image
@@ -258,6 +273,11 @@ class ProtectAIPipeline:
     @property
     def last_analysis_mode(self) -> Optional[str]:
         return self._last_analysis_mode
+
+    @property
+    def last_requested_mode(self) -> Optional[str]:
+        """The mode the camera was configured for, before any fallback."""
+        return self._last_requested_mode
 
     @property
     def last_frame_count(self) -> Optional[int]:

--- a/backend/app/services/protect_event_handler.py
+++ b/backend/app/services/protect_event_handler.py
@@ -379,6 +379,7 @@ class ProtectEventHandler:
                         event_id=generated_event_id,
                         event_timestamp=event_timestamp,
                         is_doorbell_ring=is_doorbell_ring,
+                        analysis_mode=camera.analysis_mode,
                     )
 
                     snapshot_result = media.snapshot_result
@@ -786,6 +787,7 @@ class ProtectEventHandler:
                     event_id=generated_event_id,
                     event_timestamp=event_timestamp,
                     is_doorbell_ring=is_doorbell_ring,
+                    analysis_mode=camera.analysis_mode,
                 )
                 snapshot_result = media.snapshot_result
                 clip_path = media.clip_path

--- a/backend/app/services/protect_media_service.py
+++ b/backend/app/services/protect_media_service.py
@@ -66,13 +66,17 @@ class ProtectMediaService:
         event_id: str,
         event_timestamp: datetime,
         is_doorbell_ring: bool = False,
+        analysis_mode: Optional[str] = None,
     ) -> MediaBundle:
         """
         Retrieve the best available media for AI analysis of this event.
 
         Strategy:
         - Always retrieve a snapshot (needed for thumbnail + fallback)
-        - Attempt clip download for non-ring events when useful
+        - Download a motion clip ONLY when the camera's configured analysis_mode
+          needs one (``multi_frame`` or ``video_native``). ``single_frame`` cameras
+          skip the clip entirely to avoid the bandwidth/latency cost of a clip the
+          pipeline will never use. An unset mode defaults to ``multi_frame``.
         - Return a MediaBundle the AI pipeline can use
         """
         bundle = MediaBundle()
@@ -86,9 +90,11 @@ class ProtectMediaService:
             bundle.fallback_reason = "snapshot_retrieval_failed"
             return bundle
 
-        # Decide whether to attempt clip download
-        # For now: attempt for most events, skip for simple doorbell rings if desired
-        should_attempt_clip = not is_doorbell_ring
+        # The configured mode is authoritative for clip retrieval. A clip is only
+        # useful for multi_frame (frames extracted from it) and video_native (sent
+        # whole). single_frame never needs one. Default unset -> multi_frame.
+        effective_mode = analysis_mode or "multi_frame"
+        should_attempt_clip = effective_mode in ("multi_frame", "video_native")
 
         if should_attempt_clip:
             clip_path, clip_fallback = await self._download_clip(

--- a/backend/tests/test_models/test_camera.py
+++ b/backend/tests/test_models/test_camera.py
@@ -245,8 +245,14 @@ class TestCameraModel:
 class TestCameraAnalysisModeField:
     """Test suite for Camera.analysis_mode field (Story P3-3.1)"""
 
-    def test_analysis_mode_default_is_single_frame(self, db_session):
-        """AC1, AC2: New camera defaults to 'single_frame' analysis mode"""
+    def test_analysis_mode_default_is_multi_frame(self, db_session):
+        """The model-level default is now 'multi_frame' (balanced quality/cost).
+
+        Contract change: multi_frame is the project default for clip-capable
+        cameras. RTSP/USB creation through the cameras API still overrides this to
+        single_frame at the schema layer (they cannot supply a motion clip), but
+        the bare ORM column default is multi_frame.
+        """
         camera = Camera(
             name="Test Camera",
             type="rtsp",
@@ -256,7 +262,7 @@ class TestCameraAnalysisModeField:
         db_session.add(camera)
         db_session.commit()
 
-        assert camera.analysis_mode == "single_frame"
+        assert camera.analysis_mode == "multi_frame"
 
     def test_analysis_mode_single_frame(self, db_session):
         """AC1: Camera can be created with analysis_mode='single_frame'"""

--- a/backend/tests/test_services/test_fallback_chain.py
+++ b/backend/tests/test_services/test_fallback_chain.py
@@ -263,6 +263,10 @@ class TestMultiFramePath:
     async def test_clip_with_frames_uses_multi_frame(
         self, pipeline, mock_camera_protect, mock_snapshot_result, temp_clip_file
     ):
+        # Mode is authoritative: the camera must be configured multi_frame for the
+        # multi-frame path to run (previously this path was opportunistic on clip
+        # presence regardless of configured mode).
+        mock_camera_protect.analysis_mode = "multi_frame"
         orch = MagicMock()
         orch.analyze_images = AsyncMock(
             return_value=MockAIResult(success=True, description="multi frame")
@@ -300,6 +304,7 @@ class TestMultiFramePath:
         self, pipeline, mock_camera_protect, mock_snapshot_result, temp_clip_file
     ):
         """AC2: clip present but frame extraction returns nothing -> single_frame."""
+        mock_camera_protect.analysis_mode = "multi_frame"
         orch = MagicMock()
         orch.analyze_images = AsyncMock(return_value=MockAIResult(success=True))
         orch.analyze_image = AsyncMock(
@@ -327,6 +332,121 @@ class TestMultiFramePath:
         orch.analyze_images.assert_not_called()
         orch.analyze_image.assert_called_once()
         assert pipeline._last_analysis_mode == "single_frame"
+
+
+class TestModeIsAuthoritative:
+    """camera.analysis_mode drives the pipeline; it is NOT opportunistic on clip
+    availability. Regression guard for: live events silently degrading to / from
+    the configured mode."""
+
+    @pytest.mark.asyncio
+    async def test_single_frame_camera_does_not_use_multi_frame_even_with_clip(
+        self, pipeline, mock_camera_protect, mock_snapshot_result, temp_clip_file
+    ):
+        """A camera configured single_frame must stay single_frame even when a
+        clip is present and frames are extractable. Previously the pipeline was
+        opportunistic and silently upgraded to multi_frame, ignoring the
+        configured mode (and the cost ceiling that implies)."""
+        mock_camera_protect.analysis_mode = "single_frame"
+
+        orch = MagicMock()
+        orch.analyze_images = AsyncMock(return_value=MockAIResult(success=True))
+        orch.analyze_image = AsyncMock(
+            return_value=MockAIResult(success=True, description="single frame")
+        )
+
+        p_orch, p_ai, p_db = _patch_pipeline_deps(orch)
+        with p_orch, p_ai as mock_ai, p_db, patch.object(
+            pipeline, "_try_video_native_analysis", new_callable=AsyncMock, return_value=None
+        ) as mock_video, patch.object(
+            pipeline,
+            "_extract_frames_from_clip",
+            new_callable=AsyncMock,
+            return_value=([b"f1", b"f2"], [0.0, 0.5]),
+        ) as mock_extract:
+            mock_ai.load_api_keys_from_db = AsyncMock()
+            result = await pipeline.submit_snapshot_for_analysis(
+                snapshot_result=mock_snapshot_result,
+                camera=mock_camera_protect,
+                event_type="person",
+                clip_path=temp_clip_file,
+            )
+
+        assert result is not None
+        # Configured single_frame -> no clip work attempted at all.
+        mock_video.assert_not_called()
+        mock_extract.assert_not_called()
+        orch.analyze_images.assert_not_called()
+        orch.analyze_image.assert_called_once()
+        assert pipeline._last_analysis_mode == "single_frame"
+
+    @pytest.mark.asyncio
+    async def test_unset_mode_defaults_to_multi_frame(
+        self, pipeline, mock_camera_protect, mock_snapshot_result, temp_clip_file
+    ):
+        """When a camera has no analysis_mode set, the default is multi_frame."""
+        mock_camera_protect.analysis_mode = None
+
+        orch = MagicMock()
+        orch.analyze_images = AsyncMock(
+            return_value=MockAIResult(success=True, description="multi frame")
+        )
+        orch.analyze_image = AsyncMock(return_value=MockAIResult(success=True))
+
+        p_orch, p_ai, p_db = _patch_pipeline_deps(orch)
+        with p_orch, p_ai as mock_ai, p_db, patch.object(
+            pipeline, "_try_video_native_analysis", new_callable=AsyncMock, return_value=None
+        ), patch.object(
+            pipeline,
+            "_extract_frames_from_clip",
+            new_callable=AsyncMock,
+            return_value=([b"f1", b"f2", b"f3"], [0.0, 0.5, 1.0]),
+        ):
+            mock_ai.load_api_keys_from_db = AsyncMock()
+            result = await pipeline.submit_snapshot_for_analysis(
+                snapshot_result=mock_snapshot_result,
+                camera=mock_camera_protect,
+                event_type="person",
+                clip_path=temp_clip_file,
+            )
+
+        assert result is not None
+        orch.analyze_images.assert_called_once()
+        assert pipeline._last_analysis_mode == "multi_frame"
+
+    @pytest.mark.asyncio
+    async def test_multi_frame_camera_does_not_attempt_video_native(
+        self, pipeline, mock_camera_protect, mock_snapshot_result, temp_clip_file
+    ):
+        """A multi_frame camera must not silently escalate to video_native just
+        because a Gemini provider happens to be available."""
+        mock_camera_protect.analysis_mode = "multi_frame"
+
+        orch = MagicMock()
+        orch.analyze_images = AsyncMock(
+            return_value=MockAIResult(success=True, description="multi frame")
+        )
+
+        p_orch, p_ai, p_db = _patch_pipeline_deps(orch)
+        with p_orch, p_ai as mock_ai, p_db, patch.object(
+            pipeline, "_try_video_native_analysis", new_callable=AsyncMock, return_value=MockAIResult(success=True, provider="gemini")
+        ) as mock_video, patch.object(
+            pipeline,
+            "_extract_frames_from_clip",
+            new_callable=AsyncMock,
+            return_value=([b"f1", b"f2", b"f3"], [0.0, 0.5, 1.0]),
+        ):
+            mock_ai.load_api_keys_from_db = AsyncMock()
+            result = await pipeline.submit_snapshot_for_analysis(
+                snapshot_result=mock_snapshot_result,
+                camera=mock_camera_protect,
+                event_type="person",
+                clip_path=temp_clip_file,
+            )
+
+        assert result is not None
+        mock_video.assert_not_called()
+        assert pipeline._last_analysis_mode == "multi_frame"
 
 
 class TestCompleteFailure:

--- a/backend/tests/test_services/test_protect_media_service.py
+++ b/backend/tests/test_services/test_protect_media_service.py
@@ -1,0 +1,105 @@
+"""
+Unit tests for ProtectMediaService clip-download gating.
+
+The configured analysis_mode decides whether a motion clip is downloaded:
+- single_frame  -> never download a clip (snapshot only); saves bandwidth/time.
+- multi_frame   -> download a clip (frames are extracted from it downstream).
+- video_native  -> download a clip (sent natively to the provider).
+
+This guards the regression where every event downloaded a clip regardless of
+mode, and the inverse where multi_frame cameras were starved of a clip.
+"""
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.protect_media_service import (
+    ProtectMediaService,
+    reset_protect_media_service,
+)
+from app.services.snapshot_service import SnapshotResult
+
+
+@pytest.fixture
+def media_service():
+    reset_protect_media_service()
+    return ProtectMediaService()
+
+
+@pytest.fixture
+def snapshot():
+    return SnapshotResult(
+        image_base64="abc",
+        thumbnail_path="/tmp/t.jpg",
+        width=1920,
+        height=1080,
+        camera_id="cam-1",
+        timestamp=datetime.now(timezone.utc),
+    )
+
+
+async def _call(media_service, analysis_mode, is_doorbell_ring=False):
+    return await media_service.get_media_for_event(
+        controller_id="ctrl-1",
+        protect_camera_id="protect-1",
+        camera_id="cam-1",
+        camera_name="Front Door",
+        event_id="evt-1",
+        event_timestamp=datetime.now(timezone.utc),
+        is_doorbell_ring=is_doorbell_ring,
+        analysis_mode=analysis_mode,
+    )
+
+
+@pytest.mark.asyncio
+async def test_single_frame_mode_does_not_download_clip(media_service, snapshot):
+    with patch.object(
+        media_service, "_retrieve_snapshot", new_callable=AsyncMock, return_value=snapshot
+    ), patch.object(
+        media_service, "_download_clip", new_callable=AsyncMock, return_value=(Path("/tmp/c.mp4"), None)
+    ) as mock_download:
+        bundle = await _call(media_service, analysis_mode="single_frame")
+
+    mock_download.assert_not_called()
+    assert bundle.clip_path is None
+    assert bundle.has_snapshot is True
+
+
+@pytest.mark.asyncio
+async def test_multi_frame_mode_downloads_clip(media_service, snapshot):
+    with patch.object(
+        media_service, "_retrieve_snapshot", new_callable=AsyncMock, return_value=snapshot
+    ), patch.object(
+        media_service, "_download_clip", new_callable=AsyncMock, return_value=(Path("/tmp/c.mp4"), None)
+    ) as mock_download:
+        bundle = await _call(media_service, analysis_mode="multi_frame")
+
+    mock_download.assert_called_once()
+    assert bundle.clip_path == Path("/tmp/c.mp4")
+
+
+@pytest.mark.asyncio
+async def test_video_native_mode_downloads_clip(media_service, snapshot):
+    with patch.object(
+        media_service, "_retrieve_snapshot", new_callable=AsyncMock, return_value=snapshot
+    ), patch.object(
+        media_service, "_download_clip", new_callable=AsyncMock, return_value=(Path("/tmp/c.mp4"), None)
+    ) as mock_download:
+        bundle = await _call(media_service, analysis_mode="video_native")
+
+    mock_download.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_unset_mode_defaults_to_downloading_clip(media_service, snapshot):
+    """No configured mode -> multi_frame default -> clip is downloaded."""
+    with patch.object(
+        media_service, "_retrieve_snapshot", new_callable=AsyncMock, return_value=snapshot
+    ), patch.object(
+        media_service, "_download_clip", new_callable=AsyncMock, return_value=(Path("/tmp/c.mp4"), None)
+    ) as mock_download:
+        bundle = await _call(media_service, analysis_mode=None)
+
+    mock_download.assert_called_once()


### PR DESCRIPTION
## Problem

The live Protect AI pipeline decided analysis mode purely by whether a motion clip happened to download — `camera.analysis_mode` was **never read** in the live path. Any clip-download or frame-extraction hiccup silently degraded every event to `single_frame`, and the configured/default mode was ignored.

## Root cause

`ProtectAIPipeline.submit_snapshot_for_analysis` ran an opportunistic chain (`if clip_path` → video_native → multi_frame → else single_frame) with no reference to the camera's configured mode. Mode was an accident of clip availability, not configuration.

## Fix (scope: honor mode + default + backfill)

- **`ProtectAIPipeline`** now branches on `requested_mode = camera.analysis_mode or "multi_frame"`. `single_frame` skips clip work; `multi_frame` extracts frames; `video_native` falls back multi→single. Records `_last_fallback_reason` on degradation and exposes `last_requested_mode`.
- **`ProtectMediaService.get_media_for_event`** takes `analysis_mode` and downloads a clip only when the mode needs one (multi/video_native); `single_frame` = snapshot only.
- **`ProtectEventHandler`** passes `camera.analysis_mode` at both live call sites.
- **`Camera.analysis_mode`** model default flipped `single_frame` → `multi_frame`. RTSP/USB stay `single_frame` via the unchanged schema default (no clip source).
- **Migration `a1b2c3d4e5f6`** flips the DB server-default and backfills existing `source_type='protect'` rows (idempotent; RTSP/USB untouched). Upgrade/downgrade/upgrade roundtrip verified.

## Tests

New TDD red→green: `TestModeIsAuthoritative` (fallback chain) + `test_protect_media_service.py`. Regression sweep all green: fallback chain, camera model, cameras/protect/events APIs, multi-frame + protect integration.

## Cost / safety note

Multi-frame ≈ 5× the image tokens of single-frame per Protect event. The backfill makes multi-frame live for existing Protect cameras on deploy. RTSP/USB unaffected. Rollback: `alembic downgrade -1` reverts the server-default (data backfill intentionally not reversed — lossy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)