### PR TITLE
chore(protect): remove dead duplicate return None in AI pipeline handler

### DIFF
--- a/backend/app/services/protect_ai_pipeline.py
+++ b/backend/app/services/protect_ai_pipeline.py
@@ -181,7 +181,6 @@ class ProtectAIPipeline:
             logger.error(f"AI pipeline submission failed: {e}")
             self._last_fallback_reason = f"exception:{str(e)}"
             return None
-            return None
 
     async def _extract_frames_from_clip(self, clip_path: Path, camera: Camera) -> tuple[List[bytes], List[float]]:
         """


### PR DESCRIPTION
## Summary
Removes a dead, unreachable duplicate `return None` in `submit_snapshot_for_analysis`'s `except Exception` handler in `backend/app/services/protect_ai_pipeline.py`. The handler had two consecutive `return None` lines; the second was unreachable.

Trivial cleanup, no behavior change.

## Testing
- `pytest tests/test_services/test_fallback_chain.py -q` → 15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)