### PR TITLE
fix(ai): honor admin frame-extraction settings instead of hardcoding

### DIFF
--- a/backend/app/api/v1/events.py
+++ b/backend/app/api/v1/events.py
@@ -1832,11 +1832,16 @@ async def reanalyze_event(
             )
 
         elif analysis_mode == 'multi_frame' and video_path:
-            # Extract frames and analyze
+            # Extract frames and analyze. Honor the admin-configured frame_count
+            # (the AI cost driver) instead of hardcoding. extract_frames does not
+            # take sampling_strategy/offset_ms, so only the count is wired here;
+            # the live WS pipeline (extract_frames_with_timestamps) honors all three.
+            from app.services.settings_service import SettingsService
+            frame_cfg = SettingsService(db).get_frame_extraction_config()
             frame_extractor = FrameExtractor()
             extracted_frames = await frame_extractor.extract_frames(
                 clip_path=video_path,
-                frame_count=5,
+                frame_count=frame_cfg["frame_count"],
                 filter_blur=True
             )
 

--- a/backend/app/services/protect_ai_pipeline.py
+++ b/backend/app/services/protect_ai_pipeline.py
@@ -191,6 +191,14 @@ class ProtectAIPipeline:
         """
         try:
             from app.services.frame_extractor import get_frame_extractor
+            from app.services.settings_service import SettingsService
+            from app.core.database import get_db_session
+
+            # Honor the admin-configured frame settings (count / sampling strategy /
+            # offset) instead of hardcoding. Falls back to schema defaults when
+            # unset or invalid. These directly drive multi-frame AI cost.
+            with get_db_session() as db:
+                frame_cfg = SettingsService(db).get_frame_extraction_config()
 
             extractor = get_frame_extractor()
             # Use extract_frames_with_timestamps (returns a (frames, timestamps)
@@ -201,8 +209,9 @@ class ProtectAIPipeline:
             # degraded to single-frame even when a clip was available.
             frames, timestamps = await extractor.extract_frames_with_timestamps(
                 clip_path=clip_path,
-                frame_count=5,                 # Reasonable default for cost control
-                sampling_strategy="adaptive",  # content-aware selection
+                frame_count=frame_cfg["frame_count"],
+                sampling_strategy=frame_cfg["sampling_strategy"],
+                offset_ms=frame_cfg["offset_ms"],
             )
 
             # Convert to bytes if they come back as numpy arrays

--- a/backend/app/services/settings_service.py
+++ b/backend/app/services/settings_service.py
@@ -15,6 +15,23 @@ from app.utils.encryption import decrypt_password, is_encrypted
 
 logger = logging.getLogger(__name__)
 
+# Frame-extraction config — keys, allowed values, and defaults mirror the
+# SystemSettings schema (app/schemas/system.py). These three admin settings drive
+# multi-frame AI analysis cost/quality; they are read here so the live pipeline
+# and the reanalyze endpoint share one validated source of truth.
+_FRAME_COUNT_KEY = "settings_analysis_frame_count"
+_FRAME_COUNT_ALLOWED = (5, 10, 15, 20)
+_FRAME_COUNT_DEFAULT = 10
+
+_SAMPLING_KEY = "settings_frame_sampling_strategy"
+_SAMPLING_ALLOWED = ("uniform", "adaptive", "hybrid")
+_SAMPLING_DEFAULT = "uniform"
+
+_OFFSET_KEY = "settings_frame_extraction_offset_ms"
+_OFFSET_MIN_MS = 0
+_OFFSET_MAX_MS = 10000
+_OFFSET_DEFAULT_MS = 2000
+
 
 class SettingsService:
     """
@@ -86,6 +103,64 @@ class SettingsService:
 
         # Return raw value if not encrypted
         return value
+
+    def get_frame_extraction_config(self) -> dict:
+        """
+        Resolve the admin-configured frame-extraction settings into validated
+        values safe to hand directly to FrameExtractor.
+
+        Returns a dict: {"frame_count": int, "sampling_strategy": str,
+        "offset_ms": int}. Missing, non-numeric, or out-of-range values fall back
+        to the SystemSettings schema defaults rather than reaching the extractor.
+        """
+        # Frame count — must be one of the allowed discrete choices.
+        frame_count = _FRAME_COUNT_DEFAULT
+        raw_count = self.get_setting(_FRAME_COUNT_KEY)
+        if raw_count is not None:
+            try:
+                parsed = int(raw_count)
+                if parsed in _FRAME_COUNT_ALLOWED:
+                    frame_count = parsed
+                else:
+                    logger.warning(
+                        f"{_FRAME_COUNT_KEY}={raw_count!r} not in {_FRAME_COUNT_ALLOWED}; "
+                        f"using default {_FRAME_COUNT_DEFAULT}"
+                    )
+            except (TypeError, ValueError):
+                logger.warning(
+                    f"{_FRAME_COUNT_KEY}={raw_count!r} is not an int; "
+                    f"using default {_FRAME_COUNT_DEFAULT}"
+                )
+
+        # Sampling strategy — must be one of the allowed names.
+        sampling_strategy = _SAMPLING_DEFAULT
+        raw_strategy = self.get_setting(_SAMPLING_KEY)
+        if raw_strategy is not None:
+            if raw_strategy in _SAMPLING_ALLOWED:
+                sampling_strategy = raw_strategy
+            else:
+                logger.warning(
+                    f"{_SAMPLING_KEY}={raw_strategy!r} not in {_SAMPLING_ALLOWED}; "
+                    f"using default {_SAMPLING_DEFAULT}"
+                )
+
+        # Offset — numeric, clamped to the schema range.
+        offset_ms = _OFFSET_DEFAULT_MS
+        raw_offset = self.get_setting(_OFFSET_KEY)
+        if raw_offset is not None:
+            try:
+                offset_ms = max(_OFFSET_MIN_MS, min(_OFFSET_MAX_MS, int(raw_offset)))
+            except (TypeError, ValueError):
+                logger.warning(
+                    f"{_OFFSET_KEY}={raw_offset!r} is not an int; "
+                    f"using default {_OFFSET_DEFAULT_MS}"
+                )
+
+        return {
+            "frame_count": frame_count,
+            "sampling_strategy": sampling_strategy,
+            "offset_ms": offset_ms,
+        }
 
     def set_setting(self, key: str, value: str) -> None:
         """

--- a/backend/tests/test_services/test_fallback_chain.py
+++ b/backend/tests/test_services/test_fallback_chain.py
@@ -449,6 +449,36 @@ class TestModeIsAuthoritative:
         assert pipeline._last_analysis_mode == "multi_frame"
 
 
+class TestFrameSettingsWiring:
+    """_extract_frames_from_clip honors admin-configured frame settings instead
+    of hardcoding 5/adaptive/0."""
+
+    @pytest.mark.asyncio
+    async def test_extract_passes_configured_settings_to_extractor(
+        self, pipeline, mock_camera_protect, temp_clip_file
+    ):
+        extractor = MagicMock()
+        extractor.extract_frames_with_timestamps = AsyncMock(return_value=([b"f1"], [0.0]))
+
+        fake_settings = MagicMock()
+        fake_settings.get_frame_extraction_config.return_value = {
+            "frame_count": 15,
+            "sampling_strategy": "hybrid",
+            "offset_ms": 3000,
+        }
+
+        with patch("app.services.frame_extractor.get_frame_extractor", return_value=extractor), \
+             patch("app.services.settings_service.SettingsService", return_value=fake_settings), \
+             patch("app.core.database.get_db_session"):
+            await pipeline._extract_frames_from_clip(temp_clip_file, mock_camera_protect)
+
+        extractor.extract_frames_with_timestamps.assert_called_once()
+        kwargs = extractor.extract_frames_with_timestamps.call_args.kwargs
+        assert kwargs["frame_count"] == 15
+        assert kwargs["sampling_strategy"] == "hybrid"
+        assert kwargs["offset_ms"] == 3000
+
+
 class TestCompleteFailure:
     """All paths raise -> submit returns None and records an exception reason (AC3)."""
 

--- a/backend/tests/test_services/test_settings_service_frame_config.py
+++ b/backend/tests/test_services/test_settings_service_frame_config.py
@@ -1,0 +1,61 @@
+"""
+Unit tests for SettingsService.get_frame_extraction_config().
+
+Wires the previously-dead admin settings back into a single typed reader so the
+live AI pipeline and the reanalyze endpoint honor admin-configured frame count,
+sampling strategy, and extraction offset. Defaults mirror the SystemSettings
+schema (analysis_frame_count=10, frame_sampling_strategy="uniform",
+frame_extraction_offset_ms=2000), and invalid/out-of-range values fall back to
+those defaults rather than reaching the extractor.
+"""
+import pytest
+
+from app.models.system_setting import SystemSetting
+from app.services.settings_service import SettingsService
+
+
+def _set(db, key, value):
+    db.add(SystemSetting(key=key, value=str(value)))
+    db.commit()
+
+
+def test_defaults_when_no_settings(db_session):
+    cfg = SettingsService(db_session).get_frame_extraction_config()
+    assert cfg["frame_count"] == 10
+    assert cfg["sampling_strategy"] == "uniform"
+    assert cfg["offset_ms"] == 2000
+
+
+def test_reads_configured_values(db_session):
+    _set(db_session, "settings_analysis_frame_count", 5)
+    _set(db_session, "settings_frame_sampling_strategy", "hybrid")
+    _set(db_session, "settings_frame_extraction_offset_ms", 3000)
+
+    cfg = SettingsService(db_session).get_frame_extraction_config()
+    assert cfg["frame_count"] == 5
+    assert cfg["sampling_strategy"] == "hybrid"
+    assert cfg["offset_ms"] == 3000
+
+
+def test_invalid_frame_count_falls_back_to_default(db_session):
+    _set(db_session, "settings_analysis_frame_count", "99")  # not in {5,10,15,20}
+    cfg = SettingsService(db_session).get_frame_extraction_config()
+    assert cfg["frame_count"] == 10
+
+
+def test_non_numeric_frame_count_falls_back(db_session):
+    _set(db_session, "settings_analysis_frame_count", "abc")
+    cfg = SettingsService(db_session).get_frame_extraction_config()
+    assert cfg["frame_count"] == 10
+
+
+def test_invalid_sampling_strategy_falls_back(db_session):
+    _set(db_session, "settings_frame_sampling_strategy", "magic")
+    cfg = SettingsService(db_session).get_frame_extraction_config()
+    assert cfg["sampling_strategy"] == "uniform"
+
+
+def test_offset_out_of_range_is_clamped(db_session):
+    _set(db_session, "settings_frame_extraction_offset_ms", 999999)
+    cfg = SettingsService(db_session).get_frame_extraction_config()
+    assert cfg["offset_ms"] == 10000  # clamped to schema max


### PR DESCRIPTION
## Problem

`analysis_frame_count`, `frame_sampling_strategy`, and `frame_extraction_offset_ms` are admin-configurable in the settings UI but **read by no code** — the pipeline hardcoded `frame_count=5`, `sampling_strategy="adaptive"`, `offset_ms=0`. An admin who set "15 frames" silently got 5 (config drift / Tesler's Law). Discovered while investigating why historical multi-frame events averaged ~15 images (an older code path that *did* honor the setting → ~3x AI cost).

## Fix

- **`SettingsService.get_frame_extraction_config()`** — resolves the three `settings_`-prefixed keys into validated values, falling back to the `SystemSettings` schema defaults (10 / uniform / 2000ms) on missing, non-numeric, out-of-set, or out-of-range input.
- **Live pipeline** (`_extract_frames_from_clip`) passes all three from the config.
- **Reanalyze endpoint** wires `frame_count` (the cost driver); `extract_frames` has no sampling/offset params, documented inline.

## Tests

`get_frame_extraction_config` (defaults / valid / invalid / clamp) + `_extract_frames_from_clip` wiring, TDD red→green. Existing fallback-chain, media, events API, and multi-frame integration suites stay green (74 passed in events+integration).

## Deploy note

Prod `settings_analysis_frame_count` will be set to **5** at deploy time so re-enabling the knob does not 3x AI cost vs the prior hardcoded 5. Admins can raise it knowingly afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)