### PR TITLE
fix(protect): import numpy in _extract_frames_from_clip (NameError broke all multi-frame)

### DIFF
--- a/backend/app/services/protect_ai_pipeline.py
+++ b/backend/app/services/protect_ai_pipeline.py
@@ -189,6 +189,7 @@ class ProtectAIPipeline:
         Returns (frames_as_bytes, timestamps)
         """
         try:
+            import numpy as np  # used by the np.ndarray byte-conversion check below
             from app.services.frame_extractor import get_frame_extractor
             from app.services.settings_service import SettingsService
             from app.core.database import get_db_session

--- a/backend/tests/test_services/test_fallback_chain.py
+++ b/backend/tests/test_services/test_fallback_chain.py
@@ -478,6 +478,33 @@ class TestFrameSettingsWiring:
         assert kwargs["sampling_strategy"] == "hybrid"
         assert kwargs["offset_ms"] == 3000
 
+    @pytest.mark.asyncio
+    async def test_extract_returns_frame_bytes_not_empty(
+        self, pipeline, mock_camera_protect, temp_clip_file
+    ):
+        """Regression: _extract_frames_from_clip must RETURN the extracted byte
+        frames. A missing `import numpy as np` made the np.ndarray isinstance check
+        raise NameError on every call, which was swallowed -> [] -> every
+        multi_frame event silently degraded to single_frame in production."""
+        extractor = MagicMock()
+        extractor.extract_frames_with_timestamps = AsyncMock(
+            return_value=([b"f1", b"f2", b"f3"], [0.0, 0.5, 1.0])
+        )
+        fake_settings = MagicMock()
+        fake_settings.get_frame_extraction_config.return_value = {
+            "frame_count": 5, "sampling_strategy": "adaptive", "offset_ms": 0,
+        }
+
+        with patch("app.services.frame_extractor.get_frame_extractor", return_value=extractor), \
+             patch("app.services.settings_service.SettingsService", return_value=fake_settings), \
+             patch("app.core.database.get_db_session"):
+            frames, timestamps = await pipeline._extract_frames_from_clip(
+                temp_clip_file, mock_camera_protect
+            )
+
+        assert frames == [b"f1", b"f2", b"f3"]
+        assert timestamps == [0.0, 0.5, 1.0]
+
 
 class TestCompleteFailure:
     """All paths raise -> submit returns None and records an exception reason (AC3)."""


### PR DESCRIPTION
## Problem

After #523/#525, prod events were **still single_frame**. Investigation on prod showed every multi-frame extraction failing with:

```
Frame extraction failed for clip ...: name 'np' is not defined
```

Even when the clip downloaded successfully (Driveway, Back Door), the event was stored single_frame with no recorded reason.

## Root cause

`_extract_frames_from_clip` references `np.ndarray` in its byte-conversion check, but `numpy` was never imported in the method or module. The `NameError` was swallowed by the surrounding `try/except`, returning `[]` → pipeline falls back to single_frame.

Latent until #523 made the live pipeline actually request multi_frame and download clips — which finally exercised this path.

## Fix

- `import numpy as np` in `_extract_frames_from_clip`.
- Regression test asserts the method **returns** the extracted byte frames. The prior wiring test only asserted the call args, so it never caught the swallowed `NameError` (it reproduced the exact prod error once the return value was checked).

## Out of scope (flagged separately)

- **Front Door** clips additionally 404/502 from the Protect controller's `/video/export` endpoint (clip not ready at request time / proxy error). Single_frame fallback there is correct; it's a partly-external issue.
- The event's persisted `fallback_reason` reflects only the media-layer reason, not the pipeline's `_last_fallback_reason` — an observability gap that hid this (events showed `fb=None` instead of `multi_frame_failed:...`).

## Tests

Regression test red→green; full fallback-chain, settings, media, multi-frame integration, and events API suites green (99 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)