### PR TITLE
fix(protect): persist the pipeline's actual analysis_mode/frame_count/fallback

### DIFF
--- a/backend/app/services/protect_event_handler.py
+++ b/backend/app/services/protect_event_handler.py
@@ -185,6 +185,27 @@ class ProtectEventHandler:
         # Story P3-5.3: Track last audio transcription for passing to event storage
         self._last_audio_transcription: Optional[str] = None
 
+    def _persist_tracking_kwargs(self, media_fallback: Optional[str] = None) -> dict:
+        """Assemble the analysis-mode tracking fields for event persistence from the
+        AI pipeline's per-event state.
+
+        The Phase-4 decomposition dropped this wiring: persist_protect_event was
+        called without analysis_mode / frame_count_used, so every live event was
+        stored as single_frame regardless of what the pipeline actually did, and
+        pipeline-level fallback reasons (e.g. ``multi_frame_failed:...``) were never
+        persisted — only the media-layer reason (clip download) was.
+
+        The pipeline's own fallback reason takes precedence over the media-layer
+        reason because it is the most proximate explanation for the analysis outcome.
+        Capture this immediately after submit_snapshot_for_analysis returns, before
+        any further awaits, since ProtectAIPipeline tracks state on a singleton.
+        """
+        return {
+            "analysis_mode": self.ai_pipeline.last_analysis_mode or "single_frame",
+            "frame_count_used": self.ai_pipeline.last_frame_count,
+            "fallback_reason": self.ai_pipeline.last_fallback_reason or media_fallback,
+        }
+
     def _try_ocr_extraction(self, frame, db) -> Optional[str]:
         """Extract overlay text from a frame via OCR, if enabled in settings.
 
@@ -425,6 +446,10 @@ class ProtectEventHandler:
                         clip_path=clip_path
                     )
 
+                    # Capture the pipeline's ACTUAL analysis outcome now — singleton
+                    # state is per-event and must be read before any further awaits.
+                    persist_tracking = self._persist_tracking_kwargs(media_fallback)
+
                     # Story P3-1.4 AC3: Always cleanup clip after AI processing
                     if clip_path:
                         try:
@@ -473,6 +498,7 @@ class ProtectEventHandler:
                             event_type=filter_type,
                             is_doorbell_ring=is_doorbell_ring,
                             event_id_override=generated_event_id,
+                            **persist_tracking,
                         )
 
                         if stored_event:
@@ -494,8 +520,8 @@ class ProtectEventHandler:
                         protect_event_id=str(protect_event_id) if protect_event_id else None,
                         event_type=filter_type,
                         is_doorbell_ring=is_doorbell_ring,
-                        fallback_reason=media_fallback,
-                        event_id_override=generated_event_id
+                        event_id_override=generated_event_id,
+                        **persist_tracking,
                     )
 
                     if not stored_event:
@@ -825,6 +851,10 @@ class ProtectEventHandler:
                     clip_path=clip_path
                 )
 
+                # Capture the pipeline's ACTUAL analysis outcome now (singleton state
+                # is per-event and must be read before any further awaits).
+                persist_tracking = self._persist_tracking_kwargs(fallback_reason)
+
                 # Cleanup clip after AI processing
                 if clip_path:
                     try:
@@ -844,6 +874,7 @@ class ProtectEventHandler:
                         event_type=filter_type,
                         is_doorbell_ring=is_doorbell_ring,
                         event_id_override=generated_event_id,
+                        **persist_tracking,
                     )
                     if stored_event:
                         await self.broadcaster.broadcast_event_created(stored_event, camera)
@@ -861,8 +892,8 @@ class ProtectEventHandler:
                     protect_event_id=str(protect_event_id) if protect_event_id else None,
                     event_type=filter_type,
                     is_doorbell_ring=is_doorbell_ring,
-                    fallback_reason=fallback_reason,
                     event_id_override=generated_event_id,
+                    **persist_tracking,
                 )
 
                 if not stored_event:

--- a/backend/tests/test_services/test_protect_event_handler.py
+++ b/backend/tests/test_services/test_protect_event_handler.py
@@ -801,3 +801,42 @@ class TestHomekitDoorbellTrigger:
             result = broadcaster.trigger_homekit_doorbell("cam-123", "event-456")
 
         assert result is False
+
+
+class TestPersistTrackingKwargs:
+    """The handler must persist the AI pipeline's ACTUAL analysis_mode / frame_count
+    / fallback_reason onto the event. Regression: the Phase-4 decomposition dropped
+    this wiring, so every live event was stored as single_frame regardless of what
+    the pipeline actually did, and pipeline-level fallback reasons were never saved.
+    """
+
+    def _handler_with_pipeline(self, mode, frames, fallback):
+        h = ProtectEventHandler()
+        h.ai_pipeline = MagicMock()
+        h.ai_pipeline.last_analysis_mode = mode
+        h.ai_pipeline.last_frame_count = frames
+        h.ai_pipeline.last_fallback_reason = fallback
+        return h
+
+    def test_multi_frame_result_is_recorded(self):
+        h = self._handler_with_pipeline("multi_frame", 5, None)
+        kw = h._persist_tracking_kwargs(media_fallback=None)
+        assert kw["analysis_mode"] == "multi_frame"
+        assert kw["frame_count_used"] == 5
+        assert kw["fallback_reason"] is None
+
+    def test_unset_mode_defaults_to_single_frame(self):
+        h = self._handler_with_pipeline(None, None, None)
+        kw = h._persist_tracking_kwargs(media_fallback=None)
+        assert kw["analysis_mode"] == "single_frame"
+        assert kw["frame_count_used"] is None
+
+    def test_pipeline_fallback_reason_takes_precedence(self):
+        h = self._handler_with_pipeline("single_frame", 1, "multi_frame_failed:boom")
+        kw = h._persist_tracking_kwargs(media_fallback="clip_download_failed")
+        assert kw["fallback_reason"] == "multi_frame_failed:boom"
+
+    def test_media_fallback_used_when_pipeline_has_none(self):
+        h = self._handler_with_pipeline("single_frame", 1, None)
+        kw = h._persist_tracking_kwargs(media_fallback="clip_download_failed")
+        assert kw["fallback_reason"] == "clip_download_failed"


### PR DESCRIPTION
## Problem

Even after the mode-authoritative (#523) and numpy (#526) fixes, prod events kept showing `single_frame`. Root cause: **the handler never persists the pipeline's actual result.**

All four `persist_protect_event` call sites in `ProtectEventHandler` omitted `analysis_mode` and `frame_count_used`, so the storage service defaulted them to `"single_frame"`/`None`. The Phase-4 decomposition dropped this wiring. So:
- Every live Protect event was recorded as `single_frame` regardless of what actually ran.
- Pipeline-level fallback reasons (`multi_frame_failed:...`, `multi_frame_unavailable:no_frames`) were never saved — only the media-layer clip-download reason (which is why extraction failures showed `fallback_reason=None`).

This was the original symptom ("events only processing single frames") at the *persistence* layer, hiding behind the two analysis-layer bugs already fixed.

## Fix

- New `ProtectEventHandler._persist_tracking_kwargs()` sources `analysis_mode`, `frame_count_used`, and `fallback_reason` from the AI pipeline's per-event state. Pipeline fallback reason takes precedence over the media-layer reason (most proximate to the outcome); media reason is the fallback.
- Captured immediately after `submit_snapshot_for_analysis` returns (before any further awaits — `ProtectAIPipeline` tracks state on a singleton), then passed to all four persist call sites (success + AI-failure paths in both handler blocks).

## Tests

Helper unit tests (mode recorded, single_frame default, pipeline-vs-media fallback precedence), TDD red→green. Full handler, protect/multi-frame integration, fallback-chain, and protect/events API suites green (123 + 275 passed).

## Note

`_persist_tracking_kwargs` reads singleton state right after the submit await; the clip-cleanup between submit and persist is synchronous, so the window is safe for sequential event processing. A future hardening would have `submit_snapshot_for_analysis` return a result object instead of tracking on the singleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)