### PR TITLE
fix(protect): retry transient clip gateway errors (404 + Reason: 502/503/504)

### DIFF
--- a/backend/app/services/clip_service.py
+++ b/backend/app/services/clip_service.py
@@ -568,8 +568,16 @@ class ClipService:
         except Exception as e:
             # Classify unknown exceptions
             error_str = str(e).lower()
-            # Check for 404/not found errors - non-retriable
-            if "404" in error_str or "not found" in error_str:
+            # Protect's /video/export surfaces a transient gateway failure as
+            # "Status: 404 - Reason: 502" (also 503/504) when the motion clip is not
+            # yet finalized at request time. That is RETRIABLE — the existing backoff
+            # re-requests once the clip is ready — and must be checked BEFORE the
+            # plain-404 branch so it is not misclassified as a permanent not-found.
+            is_gateway_error = any(
+                f"reason: {code}" in error_str for code in ("502", "503", "504")
+            )
+            # Check for 404/not found errors - non-retriable (true not-found only)
+            if ("404" in error_str or "not found" in error_str) and not is_gateway_error:
                 raise NonRetriableClipError(f"Clip not found: {e}") from e
             # Check for authentication errors - non-retriable
             if "auth" in error_str or "unauthorized" in error_str or "403" in error_str:

--- a/backend/tests/test_services/test_clip_service.py
+++ b/backend/tests/test_services/test_clip_service.py
@@ -332,6 +332,52 @@ class TestDownloadClip:
         assert not output_path.exists()
 
     @pytest.mark.asyncio
+    async def test_gateway_404_502_is_retriable(self):
+        """A Protect export 'Status: 404 - Reason: 502' is a transient gateway
+        error (clip not finalized yet), NOT a true not-found. It must be classified
+        RetriableClipError so the existing backoff re-requests once the clip is
+        ready, instead of immediately degrading the event to single_frame."""
+        async def gateway_502(camera_id, start, end, output_file):
+            raise Exception(
+                "Request failed: https://10.0.1.254/proxy/protect/api/video/export"
+                "?camera=cam1&start=1&end=2&channel=0 - Status: 404 - Reason: 502"
+            )
+
+        self.mock_client.get_camera_video = gateway_502
+        output_path = self.service._get_clip_path(self.event_id)
+
+        with pytest.raises(RetriableClipError):
+            await self.service._download_clip_attempt(
+                client=self.mock_client,
+                camera_id=self.camera_id,
+                event_start=self.event_start,
+                event_end=self.event_end,
+                output_path=output_path,
+            )
+
+    @pytest.mark.asyncio
+    async def test_true_404_not_found_stays_non_retriable(self):
+        """A genuine 404 (no gateway reason) means the clip does not exist; it must
+        stay NonRetriableClipError so we fail fast instead of retrying pointlessly."""
+        async def real_404(camera_id, start, end, output_file):
+            raise Exception(
+                "Request failed: https://10.0.1.254/proxy/protect/api/video/export"
+                "?camera=cam1 - Status: 404 - Reason: Not Found"
+            )
+
+        self.mock_client.get_camera_video = real_404
+        output_path = self.service._get_clip_path(self.event_id)
+
+        with pytest.raises(NonRetriableClipError):
+            await self.service._download_clip_attempt(
+                client=self.mock_client,
+                camera_id=self.camera_id,
+                event_start=self.event_start,
+                event_end=self.event_end,
+                output_path=output_path,
+            )
+
+    @pytest.mark.asyncio
     async def test_download_clip_uses_correct_parameters(self):
         """AC2, AC6: Verify correct parameters passed to uiprotect"""
         self.mock_protect._connections[self.controller_id] = self.mock_client


### PR DESCRIPTION
## Problem

Front Door events frequently fell back to single_frame because the clip download failed with:

```
Clip download failed (non-retriable): Clip not found: Request failed:
https://.../proxy/protect/api/video/export?... - Status: 404 - Reason: 502
```

`Status: 404 - Reason: 502` is a **transient gateway error** — the Protect export service hadn't finalized the motion clip yet — not a true not-found. But `_download_clip_attempt` classified any error containing `"404"` as `NonRetriableClipError`, so it failed immediately with **no retry**, degrading the event to single_frame. ~50% failure on Front Door (clips finalize slower there); Driveway/Back Door mostly succeed.

## Fix

- Detect the gateway pattern (`reason: 502/503/504`) and classify as `RetriableClipError`, **before** the plain-404 branch, so the existing exponential backoff (3 attempts, 1–4s) re-requests once the clip is ready.
- True 404s (no gateway reason) stay `NonRetriableClipError` — fail fast.
- Match the specific `reason: <code>` token rather than a bare `502` substring, to avoid spurious matches against camera ids / epoch timestamps embedded in the URL.

## Tests

`gateway-404-502 → retriable` and `true-404 → non-retriable`, TDD red→green. Full `clip_service` (68) and protect-events integration (25) suites green.

## Notes

- Worst case adds ~3–6s of backoff for a clip that never materializes, within the existing 10s/attempt timeout and documented retry behavior (NFR5); the event still gracefully falls back to single_frame after retries exhaust.
- The future-window aspect (`event_end = event_timestamp + 15s` can request not-yet-recorded footage) is naturally absorbed by retry-after-delay; not separately changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)