### PR TITLE
refactor(events): extract EventAnomalyScorer from event_processor (#530)

### DIFF
--- a/backend/app/services/event_anomaly_scorer.py
+++ b/backend/app/services/event_anomaly_scorer.py
@@ -1,0 +1,93 @@
+"""
+EventAnomalyScorer
+
+Owns the two fire-and-forget, post-storage tasks for a processed event:
+- incremental activity-baseline updates (Story P4-7.1)
+- per-event anomaly scoring (Story P4-7.2)
+
+Both run as background tasks with their own DB session (the caller's session is
+already closed by the time these run) and contain their own errors so they can
+never fail or block event processing.
+
+Extracted from EventProcessor during the Phase B decomposition (#530 / #443).
+"""
+
+import logging
+
+from app.core.database import get_db_session
+from app.core.decorators import singleton
+from app.models.event import Event
+
+logger = logging.getLogger(__name__)
+
+
+def _get_container():
+    """Lazy getter for the service container (avoids circular imports)."""
+    from app.services.service_container import container
+    return container
+
+
+@singleton
+class EventAnomalyScorer:
+    """Post-storage activity-baseline and anomaly-scoring for events."""
+
+    async def update_activity_baseline(self, camera_id: str, event: Event) -> None:
+        """
+        Update activity baseline for a camera (Story P4-7.1).
+
+        Fire-and-forget; uses its own DB session; errors are logged, not propagated.
+        """
+        try:
+            pattern_service = _get_container().pattern_service
+
+            # Use own session since caller's may be closed
+            with get_db_session() as db:
+                await pattern_service.update_baseline_incremental(db, camera_id, event)
+
+        except Exception as e:
+            # Baseline errors must not propagate (AC3)
+            logger.warning(
+                f"Activity baseline update failed for camera {camera_id}: {e}",
+                extra={
+                    "event_type": "baseline_update_error",
+                    "camera_id": camera_id,
+                    "error": str(e)
+                }
+            )
+
+    async def calculate_anomaly_score(self, event: Event) -> None:
+        """
+        Calculate and persist anomaly score for an event (Story P4-7.2).
+
+        Fire-and-forget; uses its own DB session; errors are logged, not propagated.
+        Re-fetches the event in the new session before scoring.
+        """
+        try:
+            anomaly_service = _get_container().anomaly_scoring_service
+
+            # Use own session since caller's may be closed
+            with get_db_session() as db:
+                # Re-fetch event in new session
+                event_in_session = db.query(Event).filter_by(id=event.id).first()
+                if event_in_session:
+                    await anomaly_service.score_event(db, event_in_session)
+
+        except Exception as e:
+            # Anomaly scoring errors must not propagate (AC7)
+            logger.warning(
+                f"Anomaly scoring failed for event {event.id}: {e}",
+                extra={
+                    "event_type": "anomaly_scoring_error",
+                    "event_id": event.id,
+                    "error": str(e)
+                }
+            )
+
+
+# Backward compatible getter (delegates to @singleton decorator)
+def get_event_anomaly_scorer() -> "EventAnomalyScorer":
+    return EventAnomalyScorer()
+
+
+def reset_event_anomaly_scorer() -> None:
+    EventAnomalyScorer._reset_instance()

--- a/backend/app/services/event_processor.py
+++ b/backend/app/services/event_processor.py
@@ -995,15 +995,16 @@ class EventProcessor:
                         extra={"event_id": event_id, "camera_id": event_data["camera_id"]}
                     )
 
-                    # Story P4-7.1: Update activity baseline incrementally (non-blocking)
-                    # Spawn as background task with its own session since this db will be closed
+                    # Story P4-7.1 / P4-7.2: incremental activity baseline + anomaly
+                    # scoring (non-blocking, own session). Delegated to
+                    # EventAnomalyScorer (extracted during #530 / #443 decomposition).
+                    from app.services.event_anomaly_scorer import get_event_anomaly_scorer
+                    _anomaly_scorer = get_event_anomaly_scorer()
                     asyncio.create_task(
-                        self._update_activity_baseline(event_data["camera_id"], event)
+                        _anomaly_scorer.update_activity_baseline(event_data["camera_id"], event)
                     )
-
-                    # Story P4-7.2: Calculate and persist anomaly score (non-blocking)
                     asyncio.create_task(
-                        self._calculate_anomaly_score(event)
+                        _anomaly_scorer.calculate_anomaly_score(event)
                     )
 
                     return event_id  # Return event_id instead of True
@@ -1076,83 +1077,6 @@ class EventProcessor:
                     "event_type": "mqtt_event_publish_error",
                     "event_id": event_id,
                     "topic": topic,
-                    "error": str(e)
-                }
-            )
-
-    async def _update_activity_baseline(
-        self,
-        camera_id: str,
-        event: Event
-    ) -> None:
-        """
-        Update activity baseline for a camera (Story P4-7.1).
-
-        This is a fire-and-forget async task. Errors are logged but not propagated.
-        Uses its own database session since the caller's session may be closed.
-
-        Args:
-            camera_id: Camera identifier
-            event: Event that triggered this update
-
-        Note:
-            - Non-blocking, runs as background task (AC3)
-            - Target completion time <50ms (AC2)
-            - Errors don't propagate to caller (AC3)
-        """
-        try:
-            pattern_service = _get_container().pattern_service
-
-            # Use own session since caller's may be closed
-            with get_db_session() as db:
-                await pattern_service.update_baseline_incremental(db, camera_id, event)
-
-        except Exception as e:
-            # Baseline errors must not propagate (AC3)
-            logger.warning(
-                f"Activity baseline update failed for camera {camera_id}: {e}",
-                extra={
-                    "event_type": "baseline_update_error",
-                    "camera_id": camera_id,
-                    "error": str(e)
-                }
-            )
-
-    async def _calculate_anomaly_score(
-        self,
-        event: Event
-    ) -> None:
-        """
-        Calculate and persist anomaly score for an event (Story P4-7.2).
-
-        This is a fire-and-forget async task. Errors are logged but not propagated.
-        Uses its own database session since the caller's session may be closed.
-
-        Args:
-            event: Event to score
-
-        Note:
-            - Non-blocking, runs as background task (AC7)
-            - Errors don't propagate to caller (AC7)
-            - Uses AnomalyScoringService for calculation (AC2)
-        """
-        try:
-            anomaly_service = _get_container().anomaly_scoring_service
-
-            # Use own session since caller's may be closed
-            with get_db_session() as db:
-                # Re-fetch event in new session
-                event_in_session = db.query(Event).filter_by(id=event.id).first()
-                if event_in_session:
-                    await anomaly_service.score_event(db, event_in_session)
-
-        except Exception as e:
-            # Anomaly scoring errors must not propagate (AC7)
-            logger.warning(
-                f"Anomaly scoring failed for event {event.id}: {e}",
-                extra={
-                    "event_type": "anomaly_scoring_error",
-                    "event_id": event.id,
                     "error": str(e)
                 }
             )

--- a/backend/tests/test_services/test_event_anomaly_scorer.py
+++ b/backend/tests/test_services/test_event_anomaly_scorer.py
@@ -1,0 +1,97 @@
+"""
+Unit tests for EventAnomalyScorer.
+
+Extracted from EventProcessor (#530 / #443 Phase B decomposition): owns the two
+fire-and-forget post-storage tasks — incremental activity-baseline updates and
+per-event anomaly scoring — each using its own DB session with errors contained.
+"""
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.event_anomaly_scorer import (
+    EventAnomalyScorer,
+    reset_event_anomaly_scorer,
+)
+
+
+@pytest.fixture
+def scorer():
+    reset_event_anomaly_scorer()
+    return EventAnomalyScorer()
+
+
+@contextmanager
+def _fake_session(db):
+    yield db
+
+
+def _patch(module_container, db):
+    return (
+        patch("app.services.event_anomaly_scorer._get_container", return_value=module_container),
+        patch("app.services.event_anomaly_scorer.get_db_session", lambda: _fake_session(db)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_activity_baseline_calls_pattern_service(scorer):
+    pattern_service = MagicMock()
+    pattern_service.update_baseline_incremental = AsyncMock()
+    container = SimpleNamespace(pattern_service=pattern_service)
+    db = MagicMock()
+    event = SimpleNamespace(id="evt-1")
+
+    p_c, p_db = _patch(container, db)
+    with p_c, p_db:
+        await scorer.update_activity_baseline("cam-1", event)
+
+    pattern_service.update_baseline_incremental.assert_awaited_once_with(db, "cam-1", event)
+
+
+@pytest.mark.asyncio
+async def test_calculate_anomaly_score_refetches_and_scores(scorer):
+    refetched = SimpleNamespace(id="evt-2")
+    anomaly_service = MagicMock()
+    anomaly_service.score_event = AsyncMock()
+    container = SimpleNamespace(anomaly_scoring_service=anomaly_service)
+    db = MagicMock()
+    db.query.return_value.filter_by.return_value.first.return_value = refetched
+    event = SimpleNamespace(id="evt-2")
+
+    p_c, p_db = _patch(container, db)
+    with p_c, p_db:
+        await scorer.calculate_anomaly_score(event)
+
+    anomaly_service.score_event.assert_awaited_once_with(db, refetched)
+
+
+@pytest.mark.asyncio
+async def test_calculate_anomaly_score_skips_when_event_missing(scorer):
+    anomaly_service = MagicMock()
+    anomaly_service.score_event = AsyncMock()
+    container = SimpleNamespace(anomaly_scoring_service=anomaly_service)
+    db = MagicMock()
+    db.query.return_value.filter_by.return_value.first.return_value = None
+    event = SimpleNamespace(id="gone")
+
+    p_c, p_db = _patch(container, db)
+    with p_c, p_db:
+        await scorer.calculate_anomaly_score(event)
+
+    anomaly_service.score_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_errors_are_swallowed(scorer):
+    pattern_service = MagicMock()
+    pattern_service.update_baseline_incremental = AsyncMock(side_effect=RuntimeError("db down"))
+    container = SimpleNamespace(pattern_service=pattern_service)
+    db = MagicMock()
+    event = SimpleNamespace(id="evt-3")
+
+    p_c, p_db = _patch(container, db)
+    with p_c, p_db:
+        # Must not raise.
+        await scorer.update_activity_baseline("cam-1", event)


### PR DESCRIPTION
## Context

Second decomposition of `event_processor.py` under #530 (after `EventHomeKitDispatcher` #529). Part of the #443 Phase B follow-up.

## Change

The two fire-and-forget post-storage tasks — incremental activity-baseline updates (P4-7.1) and per-event anomaly scoring (P4-7.2) — were a cohesive, self-contained concern. Extracted into a dedicated **`EventAnomalyScorer`** `@singleton`:
- `update_activity_baseline(camera_id, event)` and `calculate_anomaly_score(event)`, each with its own DB session and error containment — **behavior preserved exactly**.
- `EventProcessor._store_event_with_retry` now delegates; the two private methods (77 lines) removed.
- `event_processor.py`: **2,207 → 2,131 lines**.

## Tests

New `test_event_anomaly_scorer.py` (baseline delegation, anomaly re-fetch + score, missing-event skip, error swallowing) — TDD red→green. Verified: scorer + event_processor + alert_engine_anomaly suites green (54 passed). No tests referenced the removed methods.

Progress on #530: `EventHomeKitDispatcher` ✅ (#529), `EventAnomalyScorer` ✅ (this PR). Next candidates: `EventEntityProcessor` (high-impact), `EventMqttPublisher`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)